### PR TITLE
Add support on Windows for volumes mounted within other volumes

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,6 +22,7 @@ jobs:
       - run: dotnet build --configuration Release --no-restore
       - name: Shrink C drive and create a ReFS E drive
         run: |
+          mkdir c:\ReFS
           dir c:\
 
           echo SELECT VOLUME C:                  >DiskPartScript.txt

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -22,9 +22,12 @@ jobs:
       - run: dotnet build --configuration Release --no-restore
       - name: Shrink C drive and create a ReFS E drive
         run: |
+          dir c:\
+
           echo SELECT VOLUME C:                  >DiskPartScript.txt
-          echo SHRINK                           >>DiskPartScript.txt
+          echo SHRINK DESIRED=10240             >>DiskPartScript.txt
           echo CREATE PARTITION PRIMARY         >>DiskPartScript.txt
+          echo LIST PARTITION                   >>DiskPartScript.txt
           echo SELECT PARTITION 5               >>DiskPartScript.txt
           echo FORMAT FS=ReFS LABEL=ReFS Test   >>DiskPartScript.txt
           echo ASSIGN LETTER=E                  >>DiskPartScript.txt

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,7 +28,7 @@ jobs:
           echo SHRINK DESIRED=10240             >>DiskPartScript.txt
           echo CREATE PARTITION PRIMARY         >>DiskPartScript.txt
           echo LIST PARTITION                   >>DiskPartScript.txt
-          echo FORMAT FS=ReFS LABEL=ReFS Test   >>DiskPartScript.txt
+          echo FORMAT FS=ReFS LABEL="ReFS Test" >>DiskPartScript.txt
           echo ASSIGN LETTER=E                  >>DiskPartScript.txt
           echo LIST VOLUME                      >>DiskPartScript.txt
           echo SELECT VOLUME 4                  >>DiskPartScript.txt

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -31,7 +31,6 @@ jobs:
           echo FORMAT FS=ReFS LABEL="ReFS Test" >>DiskPartScript.txt
           echo ASSIGN LETTER=E                  >>DiskPartScript.txt
           echo LIST VOLUME                      >>DiskPartScript.txt
-          echo SELECT VOLUME 4                  >>DiskPartScript.txt
           echo ASSIGN MOUNT=C:\ReFS             >>DiskPartScript.txt
 
           diskpart /s DiskPartScript.txt

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -28,7 +28,6 @@ jobs:
           echo SHRINK DESIRED=10240             >>DiskPartScript.txt
           echo CREATE PARTITION PRIMARY         >>DiskPartScript.txt
           echo LIST PARTITION                   >>DiskPartScript.txt
-          echo SELECT PARTITION 5               >>DiskPartScript.txt
           echo FORMAT FS=ReFS LABEL=ReFS Test   >>DiskPartScript.txt
           echo ASSIGN LETTER=E                  >>DiskPartScript.txt
           echo LIST VOLUME                      >>DiskPartScript.txt

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,12 +20,24 @@ jobs:
         # No "with: dotnet-version" specified -> use global.json
       - run: dotnet restore
       - run: dotnet build --configuration Release --no-restore
-      - name: Enable Hyper-V for ReFS VHD testing
-        # Hyper-V install wants to restart and pauses console, disable that.
-        # Attempts to test VM reboot in GitHub Actions were not fruitful.
-        # We would need Hyper-V baked into an image instead.
+      - name: Shrink C drive and create a ReFS E drive
         run: |
-          DISM /Online /Enable-Feature /All /FeatureName:Microsoft-Hyper-V /NoRestart
-          if "%ERRORLEVEL%"=="3010" echo Expected 3010 exit code for pending reboot && exit /b 0
+          echo SELECT VOLUME C:                  >DiskPartScript.txt
+          echo SHRINK                           >>DiskPartScript.txt
+          echo CREATE PARTITION PRIMARY         >>DiskPartScript.txt
+          echo SELECT PARTITION 5               >>DiskPartScript.txt
+          echo FORMAT FS=ReFS LABEL=ReFS Test   >>DiskPartScript.txt
+          echo ASSIGN LETTER=E                  >>DiskPartScript.txt
+          echo LIST VOLUME                      >>DiskPartScript.txt
+          echo SELECT VOLUME 4                  >>DiskPartScript.txt
+          echo ASSIGN MOUNT=C:\ReFS             >>DiskPartScript.txt
+
+          diskpart /s DiskPartScript.txt
+          if not exist E:\ echo ERROR: diskpart failed && exit /b 1
+          if not exist C:\ReFS echo ERROR: diskpart failed && exit /b 1
+
+          @rem CODESYNC: WindowsReFSDriveSession.cs
+          SETX CoW_Test_ReFS_Drive E:\
+          exit /b 0
         shell: cmd
       - run: dotnet test --no-restore

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -20,7 +20,7 @@ jobs:
         # No "with: dotnet-version" specified -> use global.json
       - run: dotnet restore
       - run: dotnet build --configuration Release --no-restore
-      - name: Shrink C drive and create a ReFS E drive
+      - name: Shrink C drive and create a ReFS E drive, then run tests
         run: |
           mkdir c:\ReFS
           dir c:\
@@ -39,10 +39,7 @@ jobs:
           if not exist C:\ReFS echo ERROR: diskpart failed && exit /b 1
 
           @rem CODESYNC: WindowsReFSDriveSession.cs
-          SETX CoW_Test_ReFS_Drive E:\
-          set
           set CoW_Test_ReFS_Drive=E:\
 
-          exit /b 0
+          dotnet test --no-restore
         shell: cmd
-      - run: dotnet test --no-restore

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -25,14 +25,14 @@ jobs:
           mkdir c:\ReFS
           dir c:\
 
-          echo SELECT VOLUME C:                  >DiskPartScript.txt
-          echo SHRINK DESIRED=10240             >>DiskPartScript.txt
-          echo CREATE PARTITION PRIMARY         >>DiskPartScript.txt
-          echo LIST PARTITION                   >>DiskPartScript.txt
-          echo FORMAT FS=ReFS LABEL="ReFS Test" >>DiskPartScript.txt
-          echo ASSIGN LETTER=E                  >>DiskPartScript.txt
-          echo LIST VOLUME                      >>DiskPartScript.txt
-          echo ASSIGN MOUNT=C:\ReFS             >>DiskPartScript.txt
+          echo SELECT VOLUME C:                          >DiskPartScript.txt
+          echo SHRINK DESIRED=10240                     >>DiskPartScript.txt
+          echo CREATE PARTITION PRIMARY                 >>DiskPartScript.txt
+          echo LIST PARTITION                           >>DiskPartScript.txt
+          echo FORMAT QUICK FS=ReFS LABEL="ReFS Test"   >>DiskPartScript.txt
+          echo ASSIGN LETTER=E                          >>DiskPartScript.txt
+          echo LIST VOLUME                              >>DiskPartScript.txt
+          echo ASSIGN MOUNT=C:\ReFS                     >>DiskPartScript.txt
 
           diskpart /s DiskPartScript.txt
           if not exist E:\ echo ERROR: diskpart failed && exit /b 1
@@ -40,6 +40,9 @@ jobs:
 
           @rem CODESYNC: WindowsReFSDriveSession.cs
           SETX CoW_Test_ReFS_Drive E:\
+          set
+          set CoW_Test_ReFS_Drive=E:\
+
           exit /b 0
         shell: cmd
       - run: dotnet test --no-restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   <PropertyGroup>
 
     <!-- DOCSYNC: When changing version number update README.md -->
-    <Version>0.1.9.0</Version>
+    <Version>0.1.10.0</Version>
 
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   <PropertyGroup>
 
     <!-- DOCSYNC: When changing version number update README.md -->
-    <Version>0.1.8.0</Version>
+    <Version>0.1.9.0</Version>
 
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ if (canCloneInCurrentDirectory)
 ## Release History
 [NuGet package](https://www.nuget.org/packages/CopyOnWrite):
 
+* 0.1.10 September 2022: Fix missing destination file failure detection.
 * 0.1.9 September 2022: Add explicit cache invalidation call to interface.
   Update Windows implementation to detect ReFS mount points that are not drive roots, e.g. mounting D:\ (ReFS volume) under C:\ReFS.
 * 0.1.8 April 2022: Add overload for CoW clone to allow bypassing some Windows filesystem feature checks

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ if (canCloneInCurrentDirectory)
 ## Release History
 [NuGet package](https://www.nuget.org/packages/CopyOnWrite):
 
+* 0.1.9 September 2022: Add explicit cache invalidation call to interface.
+  Update Windows implementation to detect ReFS mount points that are not drive roots, e.g. mounting D:\ (ReFS volume) under C:\ReFS.
 * 0.1.8 April 2022: Add overload for CoW clone to allow bypassing some Windows filesystem feature checks
 * 0.1.7 April 2022: Perf improvement for Windows CoW link creation by reducing kernel round-trips
 * 0.1.6 April 2022: Perf improvement for all Windows APIs
@@ -100,3 +102,11 @@ Same benchmark performed on a ReFS partition (no VHD) on an M.2 SSD:
 
 ## Contributing
 This project welcomes contributions and suggestions. See CONTRIBUTING.md.
+
+### Running Unit Tests on Windows
+If you have a local ReFS drive volume on which to run ReFS related tests, set the following user or system level environment variable:
+
+  `CoW_Test_ReFS_Drive=D:\`
+
+(You may need to exit and restart VS, VSCode, or consoles after setting this.)
+When this env var is not available, unit tests create and mount a local ReFS VHD for testing, and require admin permissions.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ if (canCloneInCurrentDirectory)
 * 0.1.0 July 2021: Windows ReFS support. Mac and Linux throw NotSupportedException.
 
 
+## Contributing
+This project welcomes contributions and suggestions. See CONTRIBUTING.md.
+
+### Running Unit Tests on Windows
+If you have a local ReFS drive volume on which to run ReFS related tests, set the following user or system level environment variable:
+
+  `CoW_Test_ReFS_Drive=D:\`
+
+(You may need to exit and restart VS, VSCode, or consoles after setting this.)
+When this env var is not available, unit tests create and mount a local ReFS VHD for testing.
+You must run tests elevated (as admin), e.g. by opening Visual Studio as an admin before opening the solution.
+
+
 ## Performance Comparisons
 
 ### Windows
@@ -99,14 +112,3 @@ Same benchmark performed on a ReFS partition (no VHD) on an M.2 SSD:
 |           |          |            |           |           |            |       |         |
 | File.Copy | 16777216 | 240.713 ms | 4.7471 ms | 6.6547 ms | 240.357 ms |  1.00 |    0.00 |
 |       CoW | 16777216 |   7.291 ms | 0.3910 ms | 1.1217 ms |   7.070 ms |  0.03 |    0.01 |
-
-## Contributing
-This project welcomes contributions and suggestions. See CONTRIBUTING.md.
-
-### Running Unit Tests on Windows
-If you have a local ReFS drive volume on which to run ReFS related tests, set the following user or system level environment variable:
-
-  `CoW_Test_ReFS_Drive=D:\`
-
-(You may need to exit and restart VS, VSCode, or consoles after setting this.)
-When this env var is not available, unit tests create and mount a local ReFS VHD for testing, and require admin permissions.

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.202",
+    "version": "6.0.400",
     "rollForward": "feature"
   }
 }

--- a/lib/EnvironmentHelper.cs
+++ b/lib/EnvironmentHelper.cs
@@ -1,0 +1,61 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.CopyOnWrite;
+
+internal static class EnvironmentHelper
+{
+    /// <summary>
+    /// OS Platform of the current machine.
+    /// </summary>
+    public static OSPlatform MyOSPlatform { get; } = GetMyOSPlatform();
+
+    /// <summary>
+    /// True if OS is Linux.
+    /// </summary>
+    public static bool IsLinux => MyOSPlatform == OSPlatform.Linux;
+
+    /// <summary>
+    /// True if OS is Windows.
+    /// </summary>
+    public static bool IsWindows => MyOSPlatform == OSPlatform.Windows;
+
+    /// <summary>
+    /// True if OS is Mac.
+    /// </summary>
+    public static bool IsMac => MyOSPlatform == OSPlatform.OSX;
+
+    /// <summary>
+    /// Gets a string comparer for path comparisons.
+    /// </summary>
+    public static StringComparer PathComparer { get; } = IsWindows ? StringComparer.OrdinalIgnoreCase : StringComparer.Ordinal;
+
+    /// <summary>
+    /// Gets a string comparison for path comparisons.
+    /// </summary>
+    /// <remarks>See remarks on <see cref="PathComparer"/>.</remarks>
+    public static StringComparison PathComparison { get; } = IsWindows ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+
+    private static OSPlatform GetMyOSPlatform()
+    {
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            return OSPlatform.Windows;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            return OSPlatform.Linux;
+        }
+
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            return OSPlatform.OSX;
+        }
+
+        throw new InvalidOperationException("Cannot determine OS Platform.");
+    }
+}

--- a/lib/FileHelper.cs
+++ b/lib/FileHelper.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.IO;
+
+namespace Microsoft.CopyOnWrite;
+
+internal sealed class FileHelper
+{
+    /// <summary>
+    /// Checks if path is a subpath of a parent directory. This can include being the same directory.
+    /// Trailing path separators are allowed.
+    /// </summary>
+    /// <param name="parentDir">A relative or fully qualified path.</param>
+    /// <param name="path">Given path to check if it's a subpath of path.</param>
+    /// <returns>True if path is subpath of parentDir, false otherwise</returns>
+    public static bool IsSubpathOfPath(string parentDir, string path)
+    {
+        if (path.Length == 0)
+        {
+            return (parentDir.Length == 0);  // Empty path is subpath of the empty path.
+        }
+
+        if (parentDir.Length == 0)
+        {
+            return false;
+        }
+
+        if (parentDir[parentDir.Length - 1] != Path.DirectorySeparatorChar)
+        {
+            if (path.Length < parentDir.Length)
+            {
+                // Cannot match since it's shorter.
+                return false;
+            }
+
+            if (path.Length == parentDir.Length)
+            {
+                // path might be just path with no backslash.
+                return path.Equals(parentDir, EnvironmentHelper.PathComparison);
+            }
+
+            if (path[parentDir.Length] == Path.DirectorySeparatorChar)
+            {
+                // path has a dir separator in the right place, check if path is a simple match up to that backslash.
+                return path.StartsWith(parentDir, EnvironmentHelper.PathComparison);
+            }
+
+            return false;
+        }
+
+        // Path ends with a backslash - less common.
+        if (path.Length < parentDir.Length - 1)
+        {
+            // Cannot match since path is shorter (not including the backslash).
+            return false;
+        }
+
+        if (path.Length <= parentDir.Length)
+        {
+            // path might be just path with no backslash (for path.Length ==
+            // path.Length - 1), or a possibly simple match if path also has a trailing
+            // backslash (path.Length == path.Length).
+            return parentDir.StartsWith(path, EnvironmentHelper.PathComparison);
+        }
+
+        if (path[parentDir.Length - 1] != Path.DirectorySeparatorChar)
+        {
+            // path cannot match since the last subdir in it does not match.
+            return false;
+        }
+
+        return path.StartsWith(parentDir, EnvironmentHelper.PathComparison);
+    }
+}

--- a/lib/Linux/LinuxCopyOnWriteFilesystem.cs
+++ b/lib/Linux/LinuxCopyOnWriteFilesystem.cs
@@ -27,4 +27,9 @@ internal sealed class LinuxCopyOnWriteFilesystem : ICopyOnWriteFilesystem
         // TODO: Use ficlone().
         throw new NotImplementedException();
     }
+
+    public void ClearFilesystemCache()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/lib/Mac/MacCopyOnWriteFilesystem.cs
+++ b/lib/Mac/MacCopyOnWriteFilesystem.cs
@@ -30,4 +30,9 @@ internal sealed class MacCopyOnWriteFilesystem : ICopyOnWriteFilesystem
         // TODO: Use clonefile().
         throw new NotImplementedException();
     }
+
+    public void ClearFilesystemCache()
+    {
+        throw new NotImplementedException();
+    }
 }

--- a/lib/Windows/NativeMethods.cs
+++ b/lib/Windows/NativeMethods.cs
@@ -22,6 +22,7 @@ internal static class NativeMethods
         {
             ERROR_FILE_NOT_FOUND => new FileNotFoundException(message),
             ERROR_PATH_NOT_FOUND => new DirectoryNotFoundException(message),
+            ERROR_ACCESS_DENIED => new UnauthorizedAccessException(message),
             ERROR_INVALID_HANDLE => new UnauthorizedAccessException(message),
             ERROR_BLOCK_TOO_MANY_REFERENCES => new MaxCloneFileLinksExceededException(message),
             _ => new Win32Exception(lastErr, message)
@@ -150,6 +151,7 @@ internal static class NativeMethods
 
     public const int ERROR_FILE_NOT_FOUND = 2;
     public const int ERROR_PATH_NOT_FOUND = 3;
+    public const int ERROR_ACCESS_DENIED = 5;
     public const int ERROR_INVALID_HANDLE = 6;
     public const int ERROR_NO_MORE_FILES = 18;
     public const int ERROR_MORE_DATA = 234;

--- a/lib/Windows/NativeMethods.cs
+++ b/lib/Windows/NativeMethods.cs
@@ -224,4 +224,13 @@ internal static class NativeMethods
         [Out] StringBuilder volPathNames,
         int cBuff,
         [Out] out int retLength);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool GetVolumePathNamesForVolumeName(
+        string lpszVolumeName,
+        IntPtr lpszVolumePathNames,
+        int cchBufferLength,
+        out int lpcchReturnLength);
 }

--- a/lib/Windows/NativeMethods.cs
+++ b/lib/Windows/NativeMethods.cs
@@ -2,7 +2,9 @@
 // Licensed under the MIT License.
 
 using System;
+using System.ComponentModel;
 using System.IO;
+using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Text;
@@ -14,6 +16,19 @@ namespace Microsoft.CopyOnWrite.Windows;
 // ReSharper disable InconsistentNaming
 internal static class NativeMethods
 {
+    public static void ThrowSpecificIoException(int lastErr, string message)
+    {
+        throw lastErr switch
+        {
+            ERROR_FILE_NOT_FOUND => new FileNotFoundException(message),
+            ERROR_PATH_NOT_FOUND => new DirectoryNotFoundException(message),
+            ERROR_INVALID_HANDLE => new UnauthorizedAccessException(message),
+            ERROR_BLOCK_TOO_MANY_REFERENCES => new MaxCloneFileLinksExceededException(message),
+            _ => new Win32Exception(lastErr, message)
+        };
+    }
+
+
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     public static extern SafeFileHandle CreateFile(
@@ -136,6 +151,8 @@ internal static class NativeMethods
     public const int ERROR_FILE_NOT_FOUND = 2;
     public const int ERROR_PATH_NOT_FOUND = 3;
     public const int ERROR_INVALID_HANDLE = 6;
+    public const int ERROR_NO_MORE_FILES = 18;
+    public const int ERROR_MORE_DATA = 234;
 
     // ReFS specific WinError codes.
     public const int ERROR_BLOCK_TOO_MANY_REFERENCES = 347;
@@ -174,4 +191,37 @@ internal static class NativeMethods
         public ushort Reserved;
         public uint Flags;
     }
+
+    /// <summary>
+    /// According to MSDN: http://msdn.microsoft.com/en-us/library/aa364994(v=vs.85).aspx
+    /// </summary>
+    public const int MAX_VOLUME_GUID_LENGTH = 50;
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern SafeVolumeFindHandle FindFirstVolume(
+        [Out] StringBuilder volumeName,
+        [In] uint bufferLength);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    internal static extern bool FindNextVolume(
+        [In] SafeVolumeFindHandle hFindVolume,
+        [Out] StringBuilder volumeName,
+        [In] uint bufferLength);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+    public static extern bool FindVolumeClose([In] IntPtr handle);
+
+    [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+    [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    internal static extern bool GetVolumePathNamesForVolumeName(
+        string deviceName,
+        [Out] StringBuilder volPathNames,
+        int cBuff,
+        [Out] out int retLength);
 }

--- a/lib/Windows/SafeVolumeFindHandle.cs
+++ b/lib/Windows/SafeVolumeFindHandle.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.ConstrainedExecution;
+using Microsoft.Win32.SafeHandles;
+
+namespace Microsoft.CopyOnWrite.Windows;
+
+/// <summary>
+/// Wraps a handle for filesystem volume enumeration.
+/// </summary>
+internal sealed class SafeVolumeFindHandle : SafeHandleZeroOrMinusOneIsInvalid
+{
+    /// <summary>
+    /// Creates a volume find handle
+    /// </summary>
+    public SafeVolumeFindHandle()
+        : base(true)
+    {
+    }
+
+    /// <summary>
+    /// Override release to use proper close.
+    /// </summary>
+    /// <returns>true if successful false otherwise</returns>
+    [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
+    protected override bool ReleaseHandle()
+    {
+        return NativeMethods.FindVolumeClose(handle);
+    }
+}

--- a/lib/Windows/VolumeEnumerator.cs
+++ b/lib/Windows/VolumeEnumerator.cs
@@ -1,0 +1,150 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Microsoft.CopyOnWrite.Windows;
+
+internal sealed class VolumePaths
+{
+    internal VolumePaths(string volumeName, IReadOnlyList<string> mountedAtPaths)
+    {
+        VolumeName = volumeName;
+        MountedAtPaths = mountedAtPaths;
+
+        PrimaryDriveRootPath = string.Empty;
+        bool foundRoot = false;
+        foreach (string mountPath in mountedAtPaths)
+        {
+            if (mountPath.Length == 3)
+            {
+                // Drive letter root like "C:\"
+                PrimaryDriveRootPath = mountPath;
+                foundRoot = true;
+                break;
+            }
+        }
+
+        if (!foundRoot)
+        {
+            PrimaryDriveRootPath = volumeName + '\\';
+        }
+    }
+
+    public string VolumeName { get; }
+    public IReadOnlyList<string> MountedAtPaths { get; }
+    public string PrimaryDriveRootPath { get; }
+}
+
+/// <summary>
+/// Provides Windows disk volume enumeration, using the Win32 VolumeManager APIs.
+/// </summary>
+internal sealed class VolumeEnumerator : IDisposable
+{
+    private static readonly char[] NullChar = { '\0' };
+
+    private SafeVolumeFindHandle? _findHandle;
+
+    public void Dispose()
+    {
+        _findHandle?.Dispose();
+    }
+
+    /// <summary>
+    /// Enumerate all the volumes on the local machine. 
+    /// It returns the volume GUID path for each volume.
+    /// The Volume GUID path is of the form: "\\?\Volume{GUID}\"
+    /// </summary>
+    /// <returns></returns>
+    public IEnumerable<VolumePaths> GetVolumesAndVolumePaths()
+    {
+        while (GetNextVolume(out string? volumeName))
+        {
+            yield return new VolumePaths(volumeName!, GetVolumePathNamesForVolumeName(volumeName!));
+        }
+    }
+
+    private static string[] GetVolumePathNamesForVolumeName(string volumeName)
+    {
+        int bufferLen = 4; // Typical case: Drive letter plus null string. Eg: C:\
+        var volumePathNamesSb = new StringBuilder(bufferLen);
+
+        bool success = NativeMethods.GetVolumePathNamesForVolumeName(
+            volumeName,
+            volumePathNamesSb,
+            bufferLen,
+            out int reqBufferLen);
+        if (!success)
+        {
+            int lastErr = Marshal.GetLastWin32Error();
+            if (lastErr != NativeMethods.ERROR_MORE_DATA)
+            {
+                throw new Win32Exception(lastErr,
+                    $"GetVolumePathNamesForVolumeName({volumeName}) failed with Win32 error code {lastErr}");
+            }
+
+            // Increase the buffer size and call again.
+            bufferLen = reqBufferLen;
+            volumePathNamesSb.Capacity = reqBufferLen;
+            success = NativeMethods.GetVolumePathNamesForVolumeName(
+                volumeName,
+                volumePathNamesSb,
+                bufferLen,
+                out _);
+            if (!success)
+            {
+                lastErr = Marshal.GetLastWin32Error();
+                throw new Win32Exception(lastErr,
+                    $"GetVolumePathNamesForVolumeName({volumeName}) failed with Win32 error code {lastErr} on 2nd attempt");
+            }
+        }
+
+        // Split the output buffer into individual strings.
+        return volumePathNamesSb.ToString().Split(NullChar, StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    /// <summary>
+    /// Moves to the next volume.
+    /// </summary>
+    /// <param name="volumeName">Returns the volume when the return value is true, null otherwise.</param>
+    /// <returns>True if we found a volume. False if we reached the end.</returns>
+    private bool GetNextVolume(out string? volumeName)
+    {
+        const int bufferLen = NativeMethods.MAX_VOLUME_GUID_LENGTH;
+        var sb = new StringBuilder(bufferLen);
+        volumeName = null;
+
+        if (_findHandle == null)
+        {
+            _findHandle = NativeMethods.FindFirstVolume(sb, bufferLen);
+            if (_findHandle != null && !_findHandle.IsInvalid)
+            {
+                volumeName = sb.ToString();
+                return true;
+            }
+
+            int lastErr = Marshal.GetLastWin32Error();
+            throw new Win32Exception($"FindFirstVolume() failed with Win32 error code {lastErr}");
+        }
+
+        bool found = NativeMethods.FindNextVolume(_findHandle, sb, bufferLen);
+        if (found)
+        {
+            volumeName = sb.ToString();
+        }
+        else
+        {
+            int lastErr = Marshal.GetLastWin32Error();
+            if (lastErr != NativeMethods.ERROR_NO_MORE_FILES)
+            {
+                throw new Win32Exception($"FindNextVolume() failed with Win32 error code {lastErr}");
+            }
+        }
+
+        return found;
+    }
+}

--- a/lib/Windows/VolumeInfo.cs
+++ b/lib/Windows/VolumeInfo.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.CopyOnWrite.Windows;
+
+internal class VolumeInfo
+{
+    public VolumeInfo(string primaryDriveLetterRoot, string volumeName, bool supportsCoW, long clusterSize)
+    {
+        PrimaryDriveLetterRoot = primaryDriveLetterRoot;
+        VolumeName = volumeName;
+        SupportsCoW = supportsCoW;
+        ClusterSize = clusterSize;
+    }
+
+    /// <summary>
+    /// If the volume is mounted at a drive letter, the root directory like "C:\", else empty.
+    /// </summary>
+    public string PrimaryDriveLetterRoot { get; }
+    public string VolumeName { get; }
+
+    public bool SupportsCoW { get; }
+    public long ClusterSize { get; }
+}

--- a/lib/Windows/VolumeInfoCache.cs
+++ b/lib/Windows/VolumeInfoCache.cs
@@ -1,0 +1,145 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.CopyOnWrite.Windows;
+
+internal sealed class VolumeInfoCache
+{
+    private sealed class SubPathAndVolume
+    {
+        public SubPathAndVolume(string subPath, VolumeInfo volumeInfo)
+        {
+            SubPath = subPath;
+            Volume = volumeInfo;
+        }
+
+        public readonly string SubPath;
+        public readonly VolumeInfo Volume;
+    }
+
+    // A cheap 1-level trie to reduce string comparisons.
+    private readonly SubPathAndVolume[][] _driveLetterSubPathsSortedInReverseOrder;
+
+    public static VolumeInfoCache BuildFromCurrentFilesystem()
+    {
+        var fsInfo = new List<(VolumePaths, VolumeInfo)>();
+        using var volumeEnum = new VolumeEnumerator();
+        foreach (VolumePaths volumePaths in volumeEnum.GetVolumesAndVolumePaths())
+        {
+            fsInfo.Add((volumePaths, GetVolumeInfo(volumePaths)));
+        }
+
+        return new VolumeInfoCache(fsInfo);
+    }
+
+    // Exposed for unit testing.
+    internal VolumeInfoCache(IList<(VolumePaths, VolumeInfo)> volumesAndMountedPaths)
+    {
+        _driveLetterSubPathsSortedInReverseOrder = new SubPathAndVolume[26][];
+        for (int i = 0; i < _driveLetterSubPathsSortedInReverseOrder.Length; i++)
+        {
+            _driveLetterSubPathsSortedInReverseOrder[i] = Array.Empty<SubPathAndVolume>();
+        }
+
+        foreach ((VolumePaths volumePaths, VolumeInfo volumeInfo) in volumesAndMountedPaths)
+        {
+            foreach (string mountedPath in volumePaths.MountedAtPaths)
+            {
+                int letterIndex = IndexFromDriveLetter(mountedPath[0]);
+                SubPathAndVolume[] existingPaths = _driveLetterSubPathsSortedInReverseOrder[letterIndex];
+                var newRef = new SubPathAndVolume(mountedPath, volumeInfo);
+
+                // Typical case is for one volume to be mounted at one drive letter root path.
+                if (existingPaths.Length == 0)
+                {
+                    _driveLetterSubPathsSortedInReverseOrder[letterIndex] = new[] { newRef };
+                }
+                else
+                {
+                    var list = new List<SubPathAndVolume>(existingPaths.Length + 1) { newRef };
+                    list.AddRange(existingPaths);
+                    
+                    // Sort in reverse order to put longest paths first for subpath comparisons.
+                    list.Sort(static (s1, s2) =>
+                        string.Compare(s2.SubPath, s1.SubPath, StringComparison.OrdinalIgnoreCase));
+
+                    _driveLetterSubPathsSortedInReverseOrder[letterIndex] = list.ToArray();
+                }
+            }
+        }
+    }
+
+    public VolumeInfo GetVolumeForPath(string path)
+    {
+        // Look up paths by drive letter to reduce the size of the resulting path array to search.
+        int driveLetterIndex = IndexFromDriveLetter(path[0]);
+        SubPathAndVolume[] subPathsAndVolumes = _driveLetterSubPathsSortedInReverseOrder[driveLetterIndex];
+
+        // Paths are sorted in reverse order to get longer paths ahead of shorter paths for prefix matching.
+        // For cases where volumes are mounted under other volumes, e.g. a D: ReFS drive mounted
+        // under D:\ReFS, we want to match the deeper path.
+        foreach (SubPathAndVolume spv in subPathsAndVolumes)
+        {
+            if (FileHelper.IsSubpathOfPath(spv.SubPath, path))
+            {
+                return spv.Volume;
+            }
+        }
+
+        throw new ArgumentException($"No known volume information for '{path}'. " +
+                                    "If the drive was added recently you may need to recreate the filesystem cache.");
+    }
+
+    private static VolumeInfo GetVolumeInfo(VolumePaths volumePaths)
+    {
+        bool result = NativeMethods.GetVolumeInformation(
+            volumePaths.VolumeName,
+            null,
+            0,
+            out uint _,
+            out uint _,
+            out NativeMethods.FileSystemFeature featureFlags,
+            null,
+            0);
+        if (!result)
+        {
+            int lastErr = Marshal.GetLastWin32Error();
+            NativeMethods.ThrowSpecificIoException(lastErr,
+                $"Failed retrieving volume information for {volumePaths.PrimaryDriveRootPath} with winerror {lastErr}");
+        }
+
+        result = NativeMethods.GetDiskFreeSpace(
+            volumePaths.PrimaryDriveRootPath,
+            out ulong sectorsPerCluster,
+            out ulong bytesPerSector,
+            out ulong _,
+            out ulong _);
+        if (!result)
+        {
+            int lastErr = Marshal.GetLastWin32Error();
+            NativeMethods.ThrowSpecificIoException(lastErr,
+                $"Failed retrieving drive volume cluster layout information for {volumePaths.PrimaryDriveRootPath} with winerror {lastErr}");
+        }
+
+        return new VolumeInfo(
+            volumePaths.PrimaryDriveRootPath,
+            volumePaths.VolumeName,
+            (featureFlags & NativeMethods.FileSystemFeature.BlockRefcounting) != 0,
+            (long)(sectorsPerCluster * bytesPerSector));
+    }
+
+    private static int IndexFromDriveLetter(char driveLetter)
+    {
+        int index = driveLetter - 'A';
+        if (index > 26)
+        {
+            index -= 32;  // Difference between 'A' and 'a'
+        }
+
+        return index;
+    }
+}

--- a/lib/Windows/VolumeInfoCache.cs
+++ b/lib/Windows/VolumeInfoCache.cs
@@ -21,6 +21,8 @@ internal sealed class VolumeInfoCache
         public readonly VolumeInfo Volume;
     }
 
+    private static readonly char[] Backslash = { '\\' };
+
     // A cheap 1-level trie to reduce string comparisons.
     private readonly SubPathAndVolume[][] _driveLetterSubPathsSortedInReverseOrder;
 
@@ -49,9 +51,15 @@ internal sealed class VolumeInfoCache
         {
             foreach (string mountedPath in volumePaths.MountedAtPaths)
             {
+                string mountedPathNoBackslash = mountedPath;
+                if (mountedPath.Length > 3)
+                {
+                    mountedPathNoBackslash = mountedPath.TrimEnd(Backslash);
+                }
+
                 int letterIndex = IndexFromDriveLetter(mountedPath[0]);
                 SubPathAndVolume[] existingPaths = _driveLetterSubPathsSortedInReverseOrder[letterIndex];
-                var newRef = new SubPathAndVolume(mountedPath, volumeInfo);
+                var newRef = new SubPathAndVolume(mountedPathNoBackslash, volumeInfo);
 
                 // Typical case is for one volume to be mounted at one drive letter root path.
                 if (existingPaths.Length == 0)

--- a/lib/Windows/WindowsCopyOnWriteFilesystem.cs
+++ b/lib/Windows/WindowsCopyOnWriteFilesystem.cs
@@ -105,6 +105,12 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
         // Create an empty destination file.
         using SafeFileHandle destFileHandle = NativeMethods.CreateFile(destination, FileAccess.Write,
             FileShare.Delete, IntPtr.Zero, FileMode.Create, FileAttributes.Normal, IntPtr.Zero);
+        if (destFileHandle.IsInvalid)
+        {
+            int lastErr = Marshal.GetLastWin32Error();
+            NativeMethods.ThrowSpecificIoException(lastErr,
+                $"Failed to create destination file '{destination}' with winerror {lastErr}");
+        }
 
         long sourceFileLength;
         if ((cloneFlags & CloneFlags.NoSparseFileCheck) != 0)

--- a/lib/Windows/WindowsCopyOnWriteFilesystem.cs
+++ b/lib/Windows/WindowsCopyOnWriteFilesystem.cs
@@ -96,7 +96,7 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
             int lastErr = Marshal.GetLastWin32Error();
             if (lastErr == NativeMethods.ERROR_PATH_NOT_FOUND && Directory.Exists(resolvedSource))
             {
-                lastErr = NativeMethods.ERROR_INVALID_HANDLE;
+                lastErr = NativeMethods.ERROR_ACCESS_DENIED;
             }
             NativeMethods.ThrowSpecificIoException(lastErr,
                 $"Failed to open file with winerror {lastErr} for source file '{resolvedSource}'");

--- a/lib/Windows/WindowsCopyOnWriteFilesystem.cs
+++ b/lib/Windows/WindowsCopyOnWriteFilesystem.cs
@@ -2,9 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-using System.ComponentModel;
 using System.IO;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 using Microsoft.Win32.SafeHandles;
 
@@ -16,22 +14,10 @@ namespace Microsoft.CopyOnWrite.Windows;
 /// </summary>
 internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
 {
-    private class DriveVolumeInfo
-    {
-        public DriveVolumeInfo(bool supportsCoW, long clusterSize)
-        {
-            SupportsCoW = supportsCoW;
-            ClusterSize = clusterSize;
-        }
-
-        public bool SupportsCoW { get; }
-        public long ClusterSize { get; }
-    }
-
     // Each cloned region must be < 4GB in length. Use a smaller default.
     internal const long MaxChunkSize = 1L << 31;  // 2GB
 
-    private readonly DriveVolumeInfo?[] _driveLetterInfos = new DriveVolumeInfo?[26];
+    private VolumeInfoCache _volumeInfoCache = VolumeInfoCache.BuildFromCurrentFilesystem();
 
     // https://docs.microsoft.com/en-us/windows-server/storage/refs/block-cloning#functionality-restrictions-and-remarks
     /// <inheritdoc />
@@ -54,31 +40,15 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
             return false;
         }
 
-        char sourceDriveLetter = resolvedSource[0];
-        int sourceDriveIndex = IndexFromDriveLetter(sourceDriveLetter);
-        int destDriveIndex = IndexFromDriveLetter(resolvedDestination[0]);
-
-        // Must be on the same filesystem volume (drive letter).
-        // TODO: This does not handle a subst'd drive letter pointing to the same original volume.
-        if (sourceDriveIndex != destDriveIndex)
+        // Must be in the same volume.
+        VolumeInfo sourceVolume = _volumeInfoCache.GetVolumeForPath(resolvedSource);
+        VolumeInfo destVolume = _volumeInfoCache.GetVolumeForPath(resolvedDestination);
+        if (!ReferenceEquals(sourceVolume, destVolume))
         {
             return false;
         }
 
-        DriveVolumeInfo driveInfo = GetOrUpdateDriveVolumeInfo(sourceDriveLetter, sourceDriveIndex);
-        return driveInfo.SupportsCoW;
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static int IndexFromDriveLetter(char driveLetter)
-    {
-        int index = driveLetter - 'A';
-        if (index > 26)
-        {
-            index -= 32;  // Difference between 'A' and 'a'
-        }
-
-        return index;
+        return sourceVolume.SupportsCoW;
     }
 
     /// <inheritdoc />
@@ -90,10 +60,8 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
             return false;
         }
 
-        char sourceDriveLetter = resolvedSource[0];
-        int sourceDriveIndex = IndexFromDriveLetter(sourceDriveLetter);
-        DriveVolumeInfo driveInfo = GetOrUpdateDriveVolumeInfo(sourceDriveLetter, sourceDriveIndex);
-        return driveInfo.SupportsCoW;
+        VolumeInfo volumeInfo = _volumeInfoCache.GetVolumeForPath(resolvedSource);
+        return volumeInfo.SupportsCoW;
     }
 
     /// <inheritdoc />
@@ -114,12 +82,10 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
             throw new NotSupportedException($"Source path '{source}' is not in the correct format");
         }
 
-        char sourceDriveLetter = resolvedSource[0];
-        int sourceDriveIndex = IndexFromDriveLetter(sourceDriveLetter);
-        DriveVolumeInfo driveInfo = GetOrUpdateDriveVolumeInfo(sourceDriveLetter, sourceDriveIndex);
-        if (!driveInfo.SupportsCoW)
+        VolumeInfo sourceVolume = _volumeInfoCache.GetVolumeForPath(resolvedSource);
+        if (!sourceVolume.SupportsCoW)
         {
-            throw new NotSupportedException($@"Drive volume {sourceDriveLetter}:\ does not support copy-on-write clone links, e.g. is not formatted with ReFS");
+            throw new NotSupportedException($@"Drive volume {sourceVolume.PrimaryDriveLetterRoot} does not support copy-on-write clone links, i.e. is not formatted with ReFS");
         }
 
         // Get an open file handle to the source file.
@@ -132,7 +98,7 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
             {
                 lastErr = NativeMethods.ERROR_INVALID_HANDLE;
             }
-            ThrowSpecificIoException(lastErr,
+            NativeMethods.ThrowSpecificIoException(lastErr,
                 $"Failed to open file with winerror {lastErr} for source file '{resolvedSource}'");
         }
 
@@ -147,7 +113,7 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
             if (!NativeMethods.GetFileSizeEx(sourceFileHandle, out sourceFileLength))
             {
                 int lastErr = Marshal.GetLastWin32Error();
-                ThrowSpecificIoException(lastErr,
+                NativeMethods.ThrowSpecificIoException(lastErr,
                     $"Failed to get file info with winerror {lastErr} for source file '{resolvedSource}'");
             }
         }
@@ -157,7 +123,7 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
             if (!NativeMethods.GetFileInformationByHandle(sourceFileHandle, ref fileInfo))
             {
                 int lastErr = Marshal.GetLastWin32Error();
-                ThrowSpecificIoException(lastErr,
+                NativeMethods.ThrowSpecificIoException(lastErr,
                     $"Failed to get file info with winerror {lastErr} for source file '{resolvedSource}'");
             }
 
@@ -179,7 +145,7 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
                         IntPtr.Zero))
                 {
                     int lastErr = Marshal.GetLastWin32Error();
-                    ThrowSpecificIoException(lastErr,
+                    NativeMethods.ThrowSpecificIoException(lastErr,
                         $"Failed to set file sparseness with winerror {lastErr} for destination file '{destination}'");
                 }
             }
@@ -201,7 +167,7 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
                 IntPtr.Zero))
             {
                 int lastErr = Marshal.GetLastWin32Error();
-                ThrowSpecificIoException(lastErr,
+                NativeMethods.ThrowSpecificIoException(lastErr,
                     $"Failed to get integrity information with winerror {lastErr} from source file '{source}'");
             }
 
@@ -224,7 +190,7 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
                         IntPtr.Zero))
                 {
                     int lastErr = Marshal.GetLastWin32Error();
-                    ThrowSpecificIoException(lastErr,
+                    NativeMethods.ThrowSpecificIoException(lastErr,
                         $"Failed to set integrity information with winerror {lastErr} on destination file '{destination}'");
                 }
             }
@@ -236,7 +202,7 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
                 ref fileSizeInfo, NativeMethods.SizeOfFileEndOfFileInfo))
         {
             int lastErr = Marshal.GetLastWin32Error();
-            ThrowSpecificIoException(lastErr,
+            NativeMethods.ThrowSpecificIoException(lastErr,
                 $"Failed to set end of file with winerror {lastErr} on destination file '{destination}'");
         }
 
@@ -247,7 +213,7 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
 
         // ReFS requires that cloned regions reside on a disk cluster boundary.
         long fileSizeRoundedUpToClusterBoundary =
-            RoundUpToPowerOf2(sourceFileLength, driveInfo.ClusterSize);
+            RoundUpToPowerOf2(sourceFileLength, sourceVolume.ClusterSize);
         long sourceOffset = 0;
         while (sourceOffset < sourceFileLength)
         {
@@ -278,7 +244,7 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
                         "See https://docs.microsoft.com/en-us/windows-server/storage/refs/block-cloning#functionality-restrictions-and-remarks";
                 }
 
-                ThrowSpecificIoException(lastErr,
+                NativeMethods.ThrowSpecificIoException(lastErr,
                     $"Failed copy-on-write cloning with winerror {lastErr} from source file '{source}' to '{destination}'.{additionalMessage}");
             }
 
@@ -286,78 +252,15 @@ internal sealed class WindowsCopyOnWriteFilesystem : ICopyOnWriteFilesystem
         }
     }
 
-    private static void ThrowSpecificIoException(int lastErr, string message)
+    public void ClearFilesystemCache()
     {
-        throw lastErr switch
-        {
-            NativeMethods.ERROR_FILE_NOT_FOUND => new FileNotFoundException(message),
-            NativeMethods.ERROR_PATH_NOT_FOUND => new DirectoryNotFoundException(message),
-            NativeMethods.ERROR_INVALID_HANDLE => new UnauthorizedAccessException(message),
-            NativeMethods.ERROR_BLOCK_TOO_MANY_REFERENCES => new MaxCloneFileLinksExceededException(message),
-            _ => new Win32Exception(lastErr, message)
-        };
-    }
-
-    private DriveVolumeInfo GetOrUpdateDriveVolumeInfo(char driveLetter, int driveIndex)
-    {
-        DriveVolumeInfo? d = _driveLetterInfos[driveIndex];
-        if (d != null)
-        {
-            return d;
-        }
-
-        // Multiple threads can race to retrieve and set info, extras will be dropped in GC.
-        d = GetDriveVolumeInfo(driveLetter);
-        _driveLetterInfos[driveIndex] = d;
-        return d;
+        _volumeInfoCache = VolumeInfoCache.BuildFromCurrentFilesystem();
     }
 
     internal static long RoundUpToPowerOf2(long originalValue, long roundingMultiplePowerOf2)
     {
         long mask = roundingMultiplePowerOf2 - 1;
         return (originalValue + mask) & ~mask;
-    }
-
-    private static DriveVolumeInfo GetDriveVolumeInfo(char driveLetter)
-    {
-        return GetDriveVolumeInfo($@"{driveLetter}:\");
-    }
-
-    // driveRootPath in the form "C:\".
-    private static DriveVolumeInfo GetDriveVolumeInfo(string driveRootPath)
-    {
-        bool result = NativeMethods.GetVolumeInformation(
-            driveRootPath,
-            null,
-            0,
-            out uint _,
-            out uint _,
-            out NativeMethods.FileSystemFeature featureFlags,
-            null,
-            0);
-        if (!result)
-        {
-            int lastErr = Marshal.GetLastWin32Error();
-            ThrowSpecificIoException(lastErr,
-                $"Failed retrieving drive volume information for {driveRootPath} with winerror {lastErr}");
-        }
-
-        result = NativeMethods.GetDiskFreeSpace(
-            driveRootPath,
-            out ulong sectorsPerCluster,
-            out ulong bytesPerSector,
-            out ulong _,
-            out ulong _);
-        if (!result)
-        {
-            int lastErr = Marshal.GetLastWin32Error();
-            ThrowSpecificIoException(lastErr,
-                $"Failed retrieving drive volume cluster layout information for {driveRootPath} with winerror {lastErr}");
-        }
-
-        return new DriveVolumeInfo(
-            (featureFlags & NativeMethods.FileSystemFeature.BlockRefcounting) != 0,
-            (long)(sectorsPerCluster * bytesPerSector));
     }
 
     private static (string, bool) ResolvePathAndEnsureDriveLetterVolume(string path)

--- a/tests/benchmark/CoWComparisons.cs
+++ b/tests/benchmark/CoWComparisons.cs
@@ -16,7 +16,7 @@ public class CoWComparisons
 
     // Static to avoid multiple drives being created during benchmark and to allow control
     // of call to Dispose().
-    public static WindowsReFsVhdSession? ReFsVhdSession;
+    public static WindowsReFsDriveSession? ReFsVhdSession;
 
     public long[] FileSizesBytes { get; } =
     {
@@ -52,7 +52,7 @@ public class CoWComparisons
         string testRootDir;
         if (OsHelper.IsWindows)
         {
-            //ReFsVhdSession = WindowsReFsVhdSession.Create();
+            //ReFsVhdSession = WindowsReFsDriveSession.Create();
             //testRootDir = ReFsVhdSession.ReFsDriveRoot;
             testRootDir = @"d:\cowcompare";
         }

--- a/tests/utils/WindowsReFsDriveSession.cs
+++ b/tests/utils/WindowsReFsDriveSession.cs
@@ -24,7 +24,7 @@ public class WindowsReFsDriveSession : IDisposable
         _vhdDriveLetter = vhdDriveLetter;
         _removeVhdScriptPath = removeVhdScriptPath;
         ReFsDriveRoot = $@"{vhdDriveLetter}:\";
-        TestRootDir = Path.Combine(ReFsDriveRoot, "CoWTests", Guid.NewGuid().ToString().Substring(0, 8), testRelativeDir));
+        TestRootDir = Path.Combine(ReFsDriveRoot, "CoWTests", Guid.NewGuid().ToString().Substring(0, 8), testRelativeDir);
         Directory.CreateDirectory(TestRootDir);
     }
 

--- a/tests/utils/WindowsReFsDriveSession.cs
+++ b/tests/utils/WindowsReFsDriveSession.cs
@@ -10,27 +10,48 @@ using System.Threading;
 namespace Microsoft.CopyOnWrite.TestUtilities;
 
 /// <summary>
-/// A disposable wrapper around creation and cleanup of a ReFS filesystem in
-/// a VHD. Requires admin/elevated execution context.
+/// A disposable wrapper around either use of a predefined local drive if configured
+/// in the environment, or creation and cleanup of a ReFS filesystem in a VHD.
+/// VHD creation requires admin/elevated execution context.
 /// </summary>
-public class WindowsReFsVhdSession : IDisposable
+public class WindowsReFsDriveSession : IDisposable
 {
     private readonly char _vhdDriveLetter;
-    private readonly string _removeVhdScriptPath;
+    private readonly string? _removeVhdScriptPath;
 
-    private WindowsReFsVhdSession(char vhdDriveLetter, string removeVhdScriptPath)
+    private WindowsReFsDriveSession(char vhdDriveLetter, string? removeVhdScriptPath, string testRelativeDir)
     {
         _vhdDriveLetter = vhdDriveLetter;
         _removeVhdScriptPath = removeVhdScriptPath;
         ReFsDriveRoot = $@"{vhdDriveLetter}:\";
+        TestRootDir = Path.Combine(ReFsDriveRoot, "CoWTests", testRelativeDir);
+        Directory.CreateDirectory(TestRootDir);
     }
 
     /// <summary>
-    /// Creates a session by mounting a ReFS drive as a VHD.
-    /// Dispose the returned object to clean up the drive.
+    /// Gets the fully qualified drive root for this session, e.g. "D:\".
     /// </summary>
-    public static WindowsReFsVhdSession Create()
+    public string ReFsDriveRoot { get; }
+
+    /// <summary>
+    /// Gets the pre-created test root directory configured for this session.
+    /// </summary>
+    public string TestRootDir { get; }
+
+    /// <summary>
+    /// Creates a session by using the configured pre-created ReFS volume or by mounting a ReFS drive as a VHD.
+    /// Dispose the returned object to clean up the drive and/or test root.
+    /// </summary>
+    public static WindowsReFsDriveSession Create(string relativeTestRootDir)
     {
+        // Allow short-circuiting for CI environment and machines with locally created ReFS drives.
+        // CODESYNC: .github/workflows/CI.yaml
+        string? preCreatedReFsDriveRoot = Environment.GetEnvironmentVariable("CoW_Test_ReFS_Drive");
+        if (!string.IsNullOrEmpty(preCreatedReFsDriveRoot))
+        {
+            return new WindowsReFsDriveSession(preCreatedReFsDriveRoot[0], null, relativeTestRootDir);
+        }
+        
         var driveLetterHashSet = new HashSet<char>();
         foreach (DriveInfo driveInfo in DriveInfo.GetDrives())
         {
@@ -75,18 +96,17 @@ public class WindowsReFsVhdSession : IDisposable
         // Wait a moment for the drive mount to stabilize. A new Explorer window often opens and the first CoW link can fail.
         Thread.Sleep(1000);
         
-        return new WindowsReFsVhdSession(openDriveLetter, removeVhdScriptPath);
+        return new WindowsReFsDriveSession(openDriveLetter, removeVhdScriptPath, relativeTestRootDir);
     }
 
     public void Dispose()
     {
-        RunPowershellScript(_removeVhdScriptPath, $"{_vhdDriveLetter}");
+        Directory.Delete(TestRootDir, recursive: true);
+        if (_removeVhdScriptPath != null)
+        {
+            RunPowershellScript(_removeVhdScriptPath, $"{_vhdDriveLetter}");
+        }
     }
-
-    /// <summary>
-    /// Gets the fully qualified drive root for this session, e.g. "D:\".
-    /// </summary>
-    public string ReFsDriveRoot { get; }
 
     private static void RunPowershellScript(string scriptPath, string args)
     {

--- a/tests/utils/WindowsReFsDriveSession.cs
+++ b/tests/utils/WindowsReFsDriveSession.cs
@@ -24,7 +24,7 @@ public class WindowsReFsDriveSession : IDisposable
         _vhdDriveLetter = vhdDriveLetter;
         _removeVhdScriptPath = removeVhdScriptPath;
         ReFsDriveRoot = $@"{vhdDriveLetter}:\";
-        TestRootDir = Path.Combine(ReFsDriveRoot, "CoWTests", testRelativeDir);
+        TestRootDir = Path.Combine(ReFsDriveRoot, "CoWTests", Guid.NewGuid().ToString().Substring(0, 8), testRelativeDir)));
         Directory.CreateDirectory(TestRootDir);
     }
 

--- a/tests/utils/WindowsReFsDriveSession.cs
+++ b/tests/utils/WindowsReFsDriveSession.cs
@@ -24,7 +24,7 @@ public class WindowsReFsDriveSession : IDisposable
         _vhdDriveLetter = vhdDriveLetter;
         _removeVhdScriptPath = removeVhdScriptPath;
         ReFsDriveRoot = $@"{vhdDriveLetter}:\";
-        TestRootDir = Path.Combine(ReFsDriveRoot, "CoWTests", Guid.NewGuid().ToString().Substring(0, 8), testRelativeDir)));
+        TestRootDir = Path.Combine(ReFsDriveRoot, "CoWTests", Guid.NewGuid().ToString().Substring(0, 8), testRelativeDir));
         Directory.CreateDirectory(TestRootDir);
     }
 


### PR DESCRIPTION
E.g. mounting a ReFS volume D:\ under C;\ReFS using for example DiskPart ASSIGN MOUNT command, see CI.yaml for example.

Plus:
- Added explicit control of filesystem cache to allow invalidation by caller.
- Fixed a missing failure check for destination file creation.
- Incremented package version to 0.1.10 and published to nuget.org.
- CI now working in ADO.