### PR TITLE
Serialize Windows clones by source path

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   <PropertyGroup>
 
     <!-- DOCSYNC: When changing version number update README.md -->
-    <Version>0.1.10.0</Version>
+    <Version>0.1.11.0</Version>
 
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ if (canCloneInCurrentDirectory)
 ## Release History
 [NuGet package](https://www.nuget.org/packages/CopyOnWrite):
 
+* 0.1.11 September 2022: Serialize Windows cloning on source path to work around ReFS limitation in multithreaded cloning.
 * 0.1.10 September 2022: Fix missing destination file failure detection.
 * 0.1.9 September 2022: Add explicit cache invalidation call to interface.
   Update Windows implementation to detect ReFS mount points that are not drive roots, e.g. mounting D:\ (ReFS volume) under C:\ReFS.

--- a/lib/CopyOnWrite.csproj
+++ b/lib/CopyOnWrite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Microsoft.CopyOnWrite</RootNamespace>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
 
     <DistribDir>$(DistribRoot)Package\</DistribDir>
   </PropertyGroup>

--- a/lib/FileHelper.cs
+++ b/lib/FileHelper.cs
@@ -73,3 +73,14 @@ internal sealed class FileHelper
         return path.StartsWith(parentDir, EnvironmentHelper.PathComparison);
     }
 }
+
+internal static class FileHelperExtensions
+{
+    /// <summary>
+    /// Checks if path is subpath of the path.
+    /// </summary>
+    /// <param name="path">Given path to check if it's a subpath of <paramref name="parentDir"/>.</param>
+    /// <param name="parentDir">A relative or fully qualified path.</param>
+    /// <returns>True if path is subpath of parentDir, false otherwise.</returns>
+    public static bool IsSubpathOf(this string path, string parentDir) => FileHelper.IsSubpathOfPath(parentDir, path);
+}

--- a/lib/ICopyOnWriteFilesystem.cs
+++ b/lib/ICopyOnWriteFilesystem.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.CopyOnWrite;
 
@@ -64,7 +66,8 @@ public interface ICopyOnWriteFilesystem
     /// <summary>
     /// Creates a copy-on-write link at <paramref name="destination"/> pointing
     /// to <paramref name="source"/>, overwriting any existing file or link.
-    /// Implicitly uses <see cref="CloneFlags.None"/>.
+    /// Implicitly uses <see cref="CloneFlags.None"/>. NOTE: You should use
+    /// <see cref="CloneFileAsync"/> where possible.
     /// </summary>
     /// <param name="source">The original file to which to link.</param>
     /// <param name="destination">
@@ -92,6 +95,30 @@ public interface ICopyOnWriteFilesystem
     /// The link attempt failed because a filesystem limit on the number of clones per file was exceeded. See <see cref="MaxClonesPerFile"/>.
     /// </exception>
     void CloneFile(string source, string destination, CloneFlags cloneFlags);
+
+    /// <summary>
+    /// Creates a copy-on-write link at <paramref name="destination"/> pointing
+    /// to <paramref name="source"/>, overwriting any existing file or link.
+    /// </summary>
+    /// <param name="source">The original file to which to link.</param>
+    /// <param name="destination">
+    /// The path where the link will be created. This must not already exist as a directory,
+    /// and the parent directory must exist before this call.
+    /// </param>
+    /// <param name="cloneFlags">Flags to change behavior during creation of the CoW link.</param>
+    /// <param name="cancellationToken">A cancellation token for this operation.</param>
+    /// <exception cref="System.NotSupportedException">Copy-on-write links are not supported between source and destination.</exception>
+    /// <exception cref="MaxCloneFileLinksExceededException">
+    /// The link attempt failed because a filesystem limit on the number of clones per file was exceeded. See <see cref="MaxClonesPerFile"/>.
+    /// </exception>
+#if NET6_0 || NETSTANDARD2_1
+    ValueTask
+#elif NETSTANDARD2_0
+    Task
+#else
+#error Target Framework not supported
+#endif
+        CloneFileAsync(string source, string destination, CloneFlags cloneFlags, CancellationToken cancellationToken);
 
     /// <summary>
     /// Clears and recreates internal cached information about the computer's filesystem.
@@ -127,4 +154,11 @@ public enum CloneFlags
     /// Saves time by allowing use of less expensive kernel APIs.
     /// </summary>
     NoSparseFileCheck,
+
+    /// <summary>
+    /// Skip serialized clone creation if the OS's CoW facility cannot handle multi-threaded clone calls
+    /// in a stable way (Windows as of Server 2022 / Windows 11). Skip this check if you know that only
+    /// one clone of a source file will be performed at a time to improve performance.
+    /// </summary>
+    NoSerializedCloning,
 }

--- a/lib/Linux/LinuxCopyOnWriteFilesystem.cs
+++ b/lib/Linux/LinuxCopyOnWriteFilesystem.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.CopyOnWrite.Linux;
 
@@ -25,6 +27,19 @@ internal sealed class LinuxCopyOnWriteFilesystem : ICopyOnWriteFilesystem
     public void CloneFile(string source, string destination, CloneFlags cloneFlags)
     {
         // TODO: Use ficlone().
+        throw new NotImplementedException();
+    }
+
+    public
+#if NET6_0 || NETSTANDARD2_1
+    ValueTask
+#elif NETSTANDARD2_0
+    Task
+#else
+#error Target Framework not supported
+#endif
+        CloneFileAsync(string source, string destination, CloneFlags cloneFlags, CancellationToken cancellationToken)
+    {
         throw new NotImplementedException();
     }
 

--- a/lib/LockSet.cs
+++ b/lib/LockSet.cs
@@ -1,0 +1,188 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.CopyOnWrite;
+
+/// <summary>
+/// This type is effectively 'void', but usable as a type parameter when a value type is needed.
+/// </summary>
+/// <remarks>
+/// This is useful for generic methods dealing in tasks, since one can avoid having an overload for both
+/// <see cref="Task" /> and <see cref="Task{TResult}" />. One instead provides only a <see cref="Task{TResult}" />
+/// overload, and callers with a void result return <see cref="Void" />.
+/// </remarks>
+internal readonly struct ValueUnit
+{
+    /// <summary>
+    /// Void unit type
+    /// </summary>
+    public static readonly ValueUnit Void = new();
+}
+
+/// <summary>
+/// This is a collection of per-key exclusive locks.
+/// Borrowed from the Domino code-base
+/// </summary>
+internal sealed class LockSet<TKey> where TKey : IEquatable<TKey>
+{
+    private readonly ConcurrentDictionary<TKey, LockHandle> _exclusiveLocks;
+
+    // ReSharper disable once StaticFieldInGenericType
+    private static long _currentHandleId = 1;
+
+    public LockSet()
+    {
+        _exclusiveLocks = new ConcurrentDictionary<TKey, LockHandle>();
+    }
+
+    public LockSet(IEqualityComparer<TKey> keyComparer)
+    {
+        _exclusiveLocks = new ConcurrentDictionary<TKey, LockHandle>(keyComparer);
+    }
+
+    /// <summary>
+    /// Acquires an exclusive lock for the given key. Dispose the returned handle
+    /// to release the lock.
+    /// </summary>
+    public async
+#if NET6_0 || NETSTANDARD2_1
+    ValueTask<LockHandle>
+#elif NETSTANDARD2_0
+    Task<LockHandle>
+#else
+#error Target Framework not supported
+#endif
+        AcquireAsync(TKey key)
+    {
+        var thisHandle = new LockHandle(this, key);
+
+        while (true)
+        {
+            LockHandle currentHandle = _exclusiveLocks.GetOrAdd(key, thisHandle);
+            if (currentHandle == thisHandle)
+            {
+                break;
+            }
+
+            await currentHandle.TaskCompletionSource.Task.ConfigureAwait(false);
+        }
+
+        return thisHandle;
+    }
+
+    /// <summary>
+    /// Releases an exclusive lock for the given key. One must release a lock after first await-ing an
+    /// <see cref="AcquireAsync(TKey)" /> (by disposing the returned lock handle).
+    /// </summary>
+    private void Release(LockHandle handle)
+    {
+        bool removeSucceeded = _exclusiveLocks.TryRemoveSpecific(handle.Key, handle);
+#if DEBUG
+        if (!removeSucceeded)
+        {
+            throw new InvalidOperationException(
+                "TryRemoveSpecific should not fail, since Release should only be called after AcquireAsync.");
+        }
+#endif
+
+        handle.TaskCompletionSource.TrySetResult(ValueUnit.Void);
+    }
+
+    /// <summary>
+    /// Represents an acquired lock in the collection. Call <see cref="Dispose" />
+    /// to release the acquired lock.
+    /// </summary>
+    /// <remarks>
+    /// FxCop requires equality operations to be overloaded for value types.
+    /// Because lock handles should never be compared, these will all throw.
+    /// </remarks>
+    public readonly struct LockHandle : IEquatable<LockHandle>, IDisposable
+    {
+        private readonly LockSet<TKey> _locks;
+        private readonly long _handleId;
+
+        /// <summary>
+        /// The associated TaskCompletionSource.
+        /// </summary>
+        public readonly TaskCompletionSource<ValueUnit> TaskCompletionSource;
+            
+        /// <summary>
+        /// The associated Key.
+        /// </summary>
+        public TKey Key { get; }
+
+        /// <summary>
+        /// Construct a new instance for the given collection/key.
+        /// </summary>
+        public LockHandle(LockSet<TKey> locks, TKey key)
+        {
+            TaskCompletionSource = new TaskCompletionSource<ValueUnit>(TaskCreationOptions.RunContinuationsAsynchronously);
+            _locks = locks;
+            Key = key;
+            _handleId = Interlocked.Increment(ref _currentHandleId);
+        }
+
+        /// <inheritdoc/>
+        public void Dispose()
+        {
+            _locks.Release(this);
+        }
+
+        /// <inheritdoc/>
+        public bool Equals(LockHandle other)
+        {
+            return (this == other);
+        }
+
+        /// <inheritdoc/>
+        public override bool Equals(object? obj)
+        {
+            if (obj is LockHandle handle)
+            {
+                return Equals(handle);
+            }
+            return false;
+        }
+
+        /// <inheritdoc/>
+        public override int GetHashCode()
+        {
+            return unchecked((int)_handleId);
+        }
+
+        public static bool operator ==(LockHandle a, LockHandle b)
+        {
+            return a._handleId == b._handleId;
+        }
+
+        public static bool operator !=(LockHandle a, LockHandle b)
+        {
+            return !(a == b);
+        }
+    }
+}
+
+internal static class ConcurrentDictionaryExtensions
+{
+    /// <summary>
+    /// Attempt to remove a specific item from the ConcurrentDictionary.
+    /// </summary>
+    /// <remarks>
+    /// https://devblogs.microsoft.com/pfxteam/little-known-gems-atomic-conditional-removals-from-concurrentdictionary/
+    /// </remarks>
+    public static bool TryRemoveSpecific<TKey, TValue>(
+        this ConcurrentDictionary<TKey, TValue> dictionary,
+        TKey key,
+        TValue value)
+        where TKey: notnull
+    {
+        return ((ICollection<KeyValuePair<TKey, TValue>>)dictionary).Remove(
+            new KeyValuePair<TKey, TValue>(key, value));
+    }
+}

--- a/lib/Mac/MacCopyOnWriteFilesystem.cs
+++ b/lib/Mac/MacCopyOnWriteFilesystem.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Microsoft.CopyOnWrite.Mac;
 
@@ -28,6 +30,19 @@ internal sealed class MacCopyOnWriteFilesystem : ICopyOnWriteFilesystem
     public void CloneFile(string source, string destination, CloneFlags cloneFlags)
     {
         // TODO: Use clonefile().
+        throw new NotImplementedException();
+    }
+
+    public
+#if NET6_0 || NETSTANDARD2_1
+    ValueTask
+#elif NETSTANDARD2_0
+    Task
+#else
+#error Target Framework not supported
+#endif
+    CloneFileAsync(string source, string destination, CloneFlags cloneFlags, CancellationToken cancellationToken)
+    {
         throw new NotImplementedException();
     }
 

--- a/lib/Windows/NativeMethods.cs
+++ b/lib/Windows/NativeMethods.cs
@@ -4,13 +4,15 @@
 using System;
 using System.ComponentModel;
 using System.IO;
-using System.Runtime.ConstrainedExecution;
 using System.Runtime.InteropServices;
 using System.Runtime.InteropServices.ComTypes;
 using System.Text;
 using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.CopyOnWrite.Windows;
+
+// UnmanagedType.AsAny obsolete
+#pragma warning disable 618
 
 // ReSharper disable NotAccessedField.Local
 // ReSharper disable InconsistentNaming
@@ -215,7 +217,6 @@ internal static class NativeMethods
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
     [return: MarshalAs(UnmanagedType.Bool)]
-    [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
     public static extern bool FindVolumeClose([In] IntPtr handle);
 
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]

--- a/lib/Windows/SafeVolumeFindHandle.cs
+++ b/lib/Windows/SafeVolumeFindHandle.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Runtime.ConstrainedExecution;
 using Microsoft.Win32.SafeHandles;
 
 namespace Microsoft.CopyOnWrite.Windows;
@@ -23,7 +22,6 @@ internal sealed class SafeVolumeFindHandle : SafeHandleZeroOrMinusOneIsInvalid
     /// Override release to use proper close.
     /// </summary>
     /// <returns>true if successful false otherwise</returns>
-    [ReliabilityContract(Consistency.WillNotCorruptState, Cer.Success)]
     protected override bool ReleaseHandle()
     {
         return NativeMethods.FindVolumeClose(handle);

--- a/lib/Windows/VolumeInfoCache.cs
+++ b/lib/Windows/VolumeInfoCache.cs
@@ -92,7 +92,7 @@ internal sealed class VolumeInfoCache
         // under D:\ReFS, we want to match the deeper path.
         foreach (SubPathAndVolume spv in subPathsAndVolumes)
         {
-            if (FileHelper.IsSubpathOfPath(spv.SubPath, path))
+            if (path.IsSubpathOf(spv.SubPath))
             {
                 return spv.Volume;
             }

--- a/tests/unit/FileHelperTests.cs
+++ b/tests/unit/FileHelperTests.cs
@@ -1,0 +1,174 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CopyOnWrite.Tests;
+
+public sealed class FileHelperTests
+{
+    private static readonly string OsSpecificRoot = EnvironmentHelper.IsWindows ? @"c:\" : "/";
+
+    [TestMethod]
+    public void IsSubpathOfEmptyPathTest()
+    {
+        Assert.IsTrue(string.Empty.IsSubpathOf(string.Empty));
+        Assert.IsFalse(string.Empty.IsSubpathOf(Path.Combine("a", "b", "c")));
+    }
+
+    [TestMethod]
+    public void IsSubpathOfEmptyGivenPathTest()
+    {
+        Assert.IsTrue(string.Empty.IsSubpathOf(string.Empty));
+    }
+
+    [TestMethod]
+    public void IsSubpathOfAbsoluteFolderPathPositiveTests()
+    {
+        TestExpectedSuccessSubpaths(Path.Combine(OsSpecificRoot, "a", "b"),
+            Path.Combine(OsSpecificRoot, "a", "b", "c"),
+            Path.Combine(OsSpecificRoot, "a", "b", "a.txt"));
+    }
+
+    [TestMethod]
+    public void IsSubpathOfPathRelativeFolderPathPositiveTests()
+    {
+        TestExpectedSuccessSubpaths(@"a",
+            Path.Combine("a", "a.txt"),
+            Path.Combine("a", "b", "a.txt"));
+
+        TestExpectedSuccessSubpaths(Path.Combine("a", "b"),
+            Path.Combine("a", "b", "c"),
+            Path.Combine("a", "b", "a.txt"),
+            Path.Combine("a", "b", "c", "a.txt"));
+    }
+
+    [TestMethod]
+    public void IsSubpathOfAbsoluteFilePathPositiveTest()
+    {
+        TestExpectedSuccessSubpaths(Path.Combine(OsSpecificRoot, "a.txt"));
+        TestExpectedSuccessSubpaths(Path.Combine(OsSpecificRoot, "a", "b", "a.txt"));
+    }
+
+    [TestMethod]
+    public void IsSubpathOfRelativeFilePathPositiveTest()
+    {
+        TestExpectedSuccessSubpaths("a.txt");
+        TestExpectedSuccessSubpaths(Path.Combine("a", "b", "a.txt"));
+    }
+
+    [TestMethod]
+    public void IsSubpathOfAbsoluteFolderPathNegativeTests()
+    {
+        if (EnvironmentHelper.IsWindows)
+        {
+            TestExpectedFailSubpaths("c:", "d:");
+            TestExpectedFailSubpaths(@"c:\a\b", "c:");
+        }
+
+        TestExpectedFailSubpaths(Path.Combine(OsSpecificRoot, "a", "b"),
+            Path.Combine(OsSpecificRoot, "a"),
+            Path.Combine(OsSpecificRoot, "a", "b.txt"),
+            Path.Combine(OsSpecificRoot, "ab", "b"),
+            Path.Combine(OsSpecificRoot, "a", "c"),
+            Path.Combine(OsSpecificRoot, "a", "ba"));
+
+        TestExpectedFailSubpaths(Path.Combine(OsSpecificRoot, "foo", "barbarbar"), Path.Combine(OsSpecificRoot, "foo", "bar"));
+        TestExpectedFailSubpaths(Path.Combine(OsSpecificRoot, "foo", "bar"),
+            Path.Combine(OsSpecificRoot, "foo", "barbarbar"),
+            Path.Combine(OsSpecificRoot, "foo", "barb"));
+    }
+
+    [TestMethod]
+    public void IsSubpathOfRelativeFolderPathNegativeTests()
+    {
+        TestExpectedFailSubpaths(OsSpecificRoot,
+            "d",
+            Path.Combine("d", "c"),
+            "c.txt");
+
+        TestExpectedFailSubpaths(Path.Combine("a", "b"),
+            Path.Combine(OsSpecificRoot, "a", "b"),
+            "a",
+            Path.Combine("a", "b.txt"),
+            Path.Combine("ab", "b"),
+            Path.Combine("a", "c"),
+            Path.Combine("a", "ba"),
+            Path.Combine("c", "a", "b"));
+
+        TestExpectedFailSubpaths(Path.Combine("foo", "barbarbar"), Path.Combine("foo", "bar"));
+        TestExpectedFailSubpaths(Path.Combine("foo", "bar"),
+            Path.Combine("foo", "barbarbar"),
+            Path.Combine("foo", "barb"));
+    }
+
+    [TestMethod]
+    public void IsSubpathOfFilePathNegativeTests()
+    {
+        TestExpectedFailSubpaths(Path.Combine(OsSpecificRoot, "a.txt"),
+            Path.Combine(OsSpecificRoot, "a"),
+            Path.Combine(OsSpecificRoot, "a.txtt"),
+            Path.Combine(OsSpecificRoot, "a.tx"),
+            Path.Combine(OsSpecificRoot, "ab.txt"),
+            Path.Combine(OsSpecificRoot, "a", "a.txt"),
+            @"d:\a.txt");
+
+        TestExpectedFailSubpaths(Path.Combine(OsSpecificRoot, "a", "b", "a.txt"),
+            Path.Combine(OsSpecificRoot, "a", "b"),
+            Path.Combine(OsSpecificRoot, "a", "b", "a"),
+            Path.Combine(OsSpecificRoot, "a", "b", "atxt"),
+            Path.Combine(OsSpecificRoot, "a", "a.txt"),
+            Path.Combine(OsSpecificRoot, "a", "b", "c", "a.txt"));
+    }
+
+    private static void TestExpectedSuccessSubpaths(string compareToNoTrailingPathSeparators, params string[] expectedNoTrailingPathSeparators)
+    {
+        TestSubpaths(compareToNoTrailingPathSeparators, expectedNoTrailingPathSeparators, Assert.IsTrue);
+
+        // Further checks for the positive case.
+        string compareToWithPathSeparator = compareToNoTrailingPathSeparators + Path.DirectorySeparatorChar;
+        Assert.IsTrue(compareToNoTrailingPathSeparators.IsSubpathOf(compareToNoTrailingPathSeparators));
+        Assert.IsTrue(compareToNoTrailingPathSeparators.IsSubpathOf(compareToWithPathSeparator));
+        Assert.IsTrue(compareToWithPathSeparator.IsSubpathOf(compareToNoTrailingPathSeparators));
+        Assert.IsTrue(compareToWithPathSeparator.IsSubpathOf(compareToWithPathSeparator));
+    }
+
+    private static void TestExpectedFailSubpaths(string compareToNoTrailingPathSeparators, params string[] expectedNoTrailingPathSeparators)
+    {
+        TestSubpaths(compareToNoTrailingPathSeparators, expectedNoTrailingPathSeparators, Assert.IsFalse);
+    }
+
+    private static void TestSubpaths(string compareToNoTrailingPathSeparators, string[] expectedNoTrailingPathSeparators, Action<bool, string> assert)
+    {
+        string compareToWithPathSeparator = compareToNoTrailingPathSeparators + Path.DirectorySeparatorChar;
+
+        // Case 1: No trailing separator in both cases.
+        foreach (string expected in expectedNoTrailingPathSeparators)
+        {
+            assert(expected.IsSubpathOf(compareToNoTrailingPathSeparators), $"'{compareToNoTrailingPathSeparators}'=>'{expected}'");
+        }
+
+        // Case 2: compareTo no separator, expected with trailing.
+        foreach (string expected in expectedNoTrailingPathSeparators
+            .Select(s => s + Path.DirectorySeparatorChar))
+        {
+            assert(expected.IsSubpathOf(compareToNoTrailingPathSeparators), $"'{compareToNoTrailingPathSeparators}'=>'{expected}'");
+        }
+
+        // Case 3: compareTo separator, expected with none.
+        foreach (string expected in expectedNoTrailingPathSeparators)
+        {
+            assert(expected.IsSubpathOf(compareToWithPathSeparator), $"'{compareToWithPathSeparator}'=>'{expected}'");
+        }
+
+        // Case 4: Separator on both.
+        foreach (string expected in expectedNoTrailingPathSeparators
+            .Select(s => s + Path.DirectorySeparatorChar))
+        {
+            assert(expected.IsSubpathOf(compareToWithPathSeparator), $"'{compareToWithPathSeparator}'=>'{expected}'");
+        }
+    }
+}

--- a/tests/unit/LockSetTests.cs
+++ b/tests/unit/LockSetTests.cs
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Microsoft.CopyOnWrite.Tests;
+
+public sealed class LockSetTests
+{
+    private readonly LockSet<string> _lockSet = new();
+            
+    [TestMethod]
+    public async Task Acquire()
+    {
+        using (await _lockSet.AcquireAsync("key1"))
+        {
+        }
+    }
+
+    [TestMethod]
+    public async Task AcquireBlocksAnotherAcquireOfSameKey()
+    {
+        Task secondAcquire;
+
+        using (await _lockSet.AcquireAsync("key1"))
+        {
+            secondAcquire = Task.Run(async () =>
+            {
+                using (await _lockSet.AcquireAsync("key1"))
+                {
+                }
+            });
+            Assert.IsFalse(secondAcquire.Wait(50));
+        }
+
+        secondAcquire.Wait();
+    }
+
+    [TestMethod]
+    public async Task AcquireDoesNotBlocksAnotherAcquireOfDifferKey()
+    {
+        using (await _lockSet.AcquireAsync("key1"))
+        {
+            Task secondAcquire = Task.Run(async () =>
+            {
+                using (await _lockSet.AcquireAsync("key2"))
+                {
+                }
+            });
+
+            Assert.IsTrue(secondAcquire.Wait(5000));
+        }
+    }
+
+    [TestMethod]
+    public void DifferentKeysHaveDifferentHandles()
+    {
+        using var handle1 = _lockSet.AcquireAsync("key1").Result;
+        using var handle2 = _lockSet.AcquireAsync("key2").Result;
+        Assert.AreNotEqual(handle2, handle1);
+        Assert.AreNotEqual(handle2.GetHashCode(), handle1.GetHashCode());
+    }
+
+    [TestMethod]
+    public void EqualsGivesFalseForOtherType()
+    {
+        using var handle = _lockSet.AcquireAsync("key1").Result;
+        Assert.IsFalse(handle.Equals(new object()));
+    }
+}


### PR DESCRIPTION
Windows cannot handle multithreaded cloning at this time (#1). Also:

- Add async overload `CloneFileAsync` to allow for lock waits during serialization.
- Add package support for .NET 6 to allow use of more efficient ValueTask is available.
- Fix clone count test to allow for inexact disk limit accounting (#5).
- Increment package to 0.1.11 (published on nuget.org).