### PR TITLE
Cross-proc Windows safety and optimizations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   <PropertyGroup>
 
     <!-- DOCSYNC: When changing version number update README.md -->
-    <Version>0.1.11.0</Version>
+    <Version>0.1.12.0</Version>
 
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   <PropertyGroup>
 
     <!-- DOCSYNC: When changing version number update README.md -->
-    <Version>0.1.12.0</Version>
+    <Version>0.1.13.0</Version>
 
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ if (canCloneInCurrentDirectory)
 ## Release History
 [NuGet package](https://www.nuget.org/packages/CopyOnWrite):
 
+* 0.1.13 September 2022: Fix CloneFlags to use individual bits.
 * 0.1.12 September 2022: Add new factory flag that sets a mode to require cross-process Windows mutexes for safe source file locking to avoid a ReFS concurrency bug. Add optimization to allow bypassing redundant Path.GetFullPath() when caller has done it already.
 * 0.1.11 September 2022: Serialize Windows cloning on source path to work around ReFS limitation in multithreaded cloning.
 * 0.1.10 September 2022: Fix missing destination file failure detection.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ if (canCloneInCurrentDirectory)
 ## Release History
 [NuGet package](https://www.nuget.org/packages/CopyOnWrite):
 
+* 0.1.12 September 2022: Add new factory flag that sets a mode to require cross-process Windows mutexes for safe source file locking to avoid a ReFS concurrency bug. Add optimization to allow bypassing redundant Path.GetFullPath() when caller has done it already.
 * 0.1.11 September 2022: Serialize Windows cloning on source path to work around ReFS limitation in multithreaded cloning.
 * 0.1.10 September 2022: Fix missing destination file failure detection.
 * 0.1.9 September 2022: Add explicit cache invalidation call to interface.

--- a/lib/CopyOnWriteFilesystemFactory.cs
+++ b/lib/CopyOnWriteFilesystemFactory.cs
@@ -14,19 +14,48 @@ namespace Microsoft.CopyOnWrite;
 /// <remarks>This implementation provides access to an appdomain-wide singleton.</remarks>
 public static class CopyOnWriteFilesystemFactory
 {
-    private static readonly ICopyOnWriteFilesystem Instance = Create();
+    private static readonly Lazy<ICopyOnWriteFilesystem> InProcessLocksInstance = new(() => Create(useCrossProcessLocks: false));
+    private static readonly Lazy<ICopyOnWriteFilesystem> CrossProcessLocksInstance = new(() => Create(useCrossProcessLocks: true));
 
     /// <summary>
-    /// Gets a singleton instance of the CoW filesystem appropriate for this operating system.
+    /// Gets an instance of the CoW filesystem appropriate for this operating system.
+    /// This instance uses in-process locks where needed for the current operating system.
     /// </summary>
-    public static ICopyOnWriteFilesystem GetInstance() => Instance;
+    public static ICopyOnWriteFilesystem GetInstance() => InProcessLocksInstance.Value;
 
-    private static ICopyOnWriteFilesystem Create()
+    /// <summary>
+    /// Gets an instance of the CoW filesystem appropriate for this operating system.
+    /// </summary>
+    /// <param name="forceUniqueInstance">
+    /// Forces return of a unique instance instead of a singleton. Useful for unit tests.
+    /// This can be expensive as creating a new instance can re-scan the filesystem to fill the cache.
+    /// Consider instead using <paramref name="forceUniqueInstance"/>=false and utilize
+    /// <see cref="ICopyOnWriteFilesystem.ClearFilesystemCache"/> to clear the cache on the singleton instance.
+    /// </param>
+    /// <param name="useCrossProcessLocksWhereApplicable">
+    /// If true, uses cross-process locks where needed for the current operating system.
+    /// These locks are more expensive than in-process locks, but are required when cloning
+    /// the same source file across process boundaries. Example of cross-process requirement:
+    /// MSBuild uses many worker node processes that may all clone the same source to multiple
+    /// output locations. Counter-example for intra-process locking: If a build engine controls
+    /// all cloning of a source file from a content-addressable store into the filesystem.
+    /// </param>
+    public static ICopyOnWriteFilesystem GetInstance(bool forceUniqueInstance, bool useCrossProcessLocksWhereApplicable)
+    {
+        if (forceUniqueInstance)
+        {
+            return Create(useCrossProcessLocksWhereApplicable);
+        }
+
+        return useCrossProcessLocksWhereApplicable ? CrossProcessLocksInstance.Value : InProcessLocksInstance.Value;
+    }
+
+    private static ICopyOnWriteFilesystem Create(bool useCrossProcessLocks)
     {
         switch (Environment.OSVersion.Platform)
         {
             case PlatformID.Win32NT:
-                return new WindowsCopyOnWriteFilesystem();
+                return new WindowsCopyOnWriteFilesystem(useCrossProcessLocks);
             case PlatformID.Unix:
                 return new LinuxCopyOnWriteFilesystem();
             case PlatformID.MacOSX:

--- a/lib/ICopyOnWriteFilesystem.cs
+++ b/lib/ICopyOnWriteFilesystem.cs
@@ -45,8 +45,12 @@ public interface ICopyOnWriteFilesystem
     /// </summary>
     /// <param name="source">The file path to which the link will point.</param>
     /// <param name="destination">The file path that would contain the link.</param>
+    /// <param name="pathsAreFullyResolved">
+    /// When true, avoids expensive calls to <see cref="System.IO.Path.GetFullPath"/> to resolve the
+    /// full path by asserting that the caller already called it for the source and destination paths.
+    /// </param>
     /// <returns>True if a link can be created, false if it cannot.</returns>
-    bool CopyOnWriteLinkSupportedBetweenPaths(string source, string destination);
+    bool CopyOnWriteLinkSupportedBetweenPaths(string source, string destination, bool pathsAreFullyResolved = false);
 
     /// <summary>
     /// Determines whether copy-on-write links can be created for files at the specified
@@ -60,8 +64,12 @@ public interface ICopyOnWriteFilesystem
     /// copy-on-write links, or it can be a path under a volume mount point within
     /// another volume.
     /// </param>
+    /// <param name="pathIsFullyResolved">
+    /// When true, avoids an expensive call to <see cref="System.IO.Path.GetFullPath"/> to resolve the
+    /// full path by asserting that the caller already called it for the root path.
+    /// </param>
     /// <returns>True if a link can be created, false if it cannot.</returns>
-    bool CopyOnWriteLinkSupportedInDirectoryTree(string rootDirectory);
+    bool CopyOnWriteLinkSupportedInDirectoryTree(string rootDirectory, bool pathIsFullyResolved = false);
 
     /// <summary>
     /// Creates a copy-on-write link at <paramref name="destination"/> pointing
@@ -161,4 +169,10 @@ public enum CloneFlags
     /// one clone of a source file will be performed at a time to improve performance.
     /// </summary>
     NoSerializedCloning,
+
+    /// <summary>
+    /// Avoids expensive calls to <see cref="System.IO.Path.GetFullPath"/> to resolve the full path by asserting
+    /// that the caller already called it for the source and destination paths.
+    /// </summary>
+    PathIsFullyResolved,
 }

--- a/lib/ICopyOnWriteFilesystem.cs
+++ b/lib/ICopyOnWriteFilesystem.cs
@@ -46,7 +46,7 @@ public interface ICopyOnWriteFilesystem
     /// <param name="source">The file path to which the link will point.</param>
     /// <param name="destination">The file path that would contain the link.</param>
     /// <param name="pathsAreFullyResolved">
-    /// When true, avoids expensive calls to <see cref="System.IO.Path.GetFullPath"/> to resolve the
+    /// When true, avoids expensive calls to <see cref="System.IO.Path.GetFullPath(string)"/> to resolve the
     /// full path by asserting that the caller already called it for the source and destination paths.
     /// </param>
     /// <returns>True if a link can be created, false if it cannot.</returns>
@@ -65,7 +65,7 @@ public interface ICopyOnWriteFilesystem
     /// another volume.
     /// </param>
     /// <param name="pathIsFullyResolved">
-    /// When true, avoids an expensive call to <see cref="System.IO.Path.GetFullPath"/> to resolve the
+    /// When true, avoids an expensive call to <see cref="System.IO.Path.GetFullPath(string)"/> to resolve the
     /// full path by asserting that the caller already called it for the root path.
     /// </param>
     /// <returns>True if a link can be created, false if it cannot.</returns>
@@ -171,7 +171,7 @@ public enum CloneFlags
     NoSerializedCloning,
 
     /// <summary>
-    /// Avoids expensive calls to <see cref="System.IO.Path.GetFullPath"/> to resolve the full path by asserting
+    /// Avoids expensive calls to <see cref="System.IO.Path.GetFullPath(string)"/> to resolve the full path by asserting
     /// that the caller already called it for the source and destination paths.
     /// </summary>
     PathIsFullyResolved,

--- a/lib/ICopyOnWriteFilesystem.cs
+++ b/lib/ICopyOnWriteFilesystem.cs
@@ -147,32 +147,32 @@ public enum CloneFlags
     /// <summary>
     /// Default zero value, no behavior changes.
     /// </summary>
-    None,
+    None = 0,
 
     /// <summary>
     /// Skip check for and copy of Windows file integrity settings from source to destination.
     /// Use when the filesystem and file are known not to use integrity.
     /// Saves 1-2 kernel round-trips.
     /// </summary>
-    NoFileIntegrityCheck,
+    NoFileIntegrityCheck = 0x01,
 
     /// <summary>
     /// Skip check for Windows sparse file attribute and application of sparse setting in destination.
     /// Use when the filesystem and file are known not to be sparse.
     /// Saves time by allowing use of less expensive kernel APIs.
     /// </summary>
-    NoSparseFileCheck,
+    NoSparseFileCheck = 0x02,
 
     /// <summary>
     /// Skip serialized clone creation if the OS's CoW facility cannot handle multi-threaded clone calls
     /// in a stable way (Windows as of Server 2022 / Windows 11). Skip this check if you know that only
     /// one clone of a source file will be performed at a time to improve performance.
     /// </summary>
-    NoSerializedCloning,
+    NoSerializedCloning = 0x04,
 
     /// <summary>
     /// Avoids expensive calls to <see cref="System.IO.Path.GetFullPath(string)"/> to resolve the full path by asserting
     /// that the caller already called it for the source and destination paths.
     /// </summary>
-    PathIsFullyResolved,
+    PathIsFullyResolved = 0x08,
 }

--- a/lib/Linux/LinuxCopyOnWriteFilesystem.cs
+++ b/lib/Linux/LinuxCopyOnWriteFilesystem.cs
@@ -11,13 +11,13 @@ internal sealed class LinuxCopyOnWriteFilesystem : ICopyOnWriteFilesystem
 {
     public int MaxClonesPerFile => int.MaxValue;
 
-    public bool CopyOnWriteLinkSupportedBetweenPaths(string source, string destination)
+    public bool CopyOnWriteLinkSupportedBetweenPaths(string source, string destination, bool pathsAreFullyResolved = false)
     {
         // TODO: Implement FS probing and return a real value.
         throw new NotImplementedException();
     }
 
-    public bool CopyOnWriteLinkSupportedInDirectoryTree(string rootDirectory)
+    public bool CopyOnWriteLinkSupportedInDirectoryTree(string rootDirectory, bool pathIsFullyResolved = false)
     {
         throw new NotImplementedException();
     }

--- a/lib/Mac/MacCopyOnWriteFilesystem.cs
+++ b/lib/Mac/MacCopyOnWriteFilesystem.cs
@@ -11,14 +11,14 @@ internal sealed class MacCopyOnWriteFilesystem : ICopyOnWriteFilesystem
 {
     public int MaxClonesPerFile => int.MaxValue;
 
-    public bool CopyOnWriteLinkSupportedBetweenPaths(string source, string destination)
+    public bool CopyOnWriteLinkSupportedBetweenPaths(string source, string destination, bool pathsAreFullyResolved = false)
     {
         // AppleFS always supports CoW.
         // return true;
         throw new NotImplementedException();
     }
 
-    public bool CopyOnWriteLinkSupportedInDirectoryTree(string rootDirectory)
+    public bool CopyOnWriteLinkSupportedInDirectoryTree(string rootDirectory, bool pathIsFullyResolved = false)
     {
         // AppleFS always supports CoW.
         // return true;


### PR DESCRIPTION
Add new factory flag that sets a mode to require cross-process Windows mutexes for safe source file locking to avoid ReFS concurrency bug. Add optimization to allow bypassing redundant Path.GetFullPath() when caller has done it already. Fix CloneFlags to use individual bits (see #8).

Published new package version 0.1.13 with these changes.