### PR TITLE
Perf improvements, behavior changes

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   <PropertyGroup>
 
     <!-- DOCSYNC: When changing version number update README.md -->
-    <Version>0.1.13.0</Version>
+    <Version>0.2.0.0</Version>
 
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>

--- a/lib/ICopyOnWriteFilesystem.cs
+++ b/lib/ICopyOnWriteFilesystem.cs
@@ -157,11 +157,10 @@ public enum CloneFlags
     NoFileIntegrityCheck = 0x01,
 
     /// <summary>
-    /// Skip check for Windows sparse file attribute and application of sparse setting in destination.
-    /// Use when the filesystem and file are known not to be sparse.
-    /// Saves time by allowing use of less expensive kernel APIs.
+    /// By default, sparse destination files are used to speed up cloning. The file is typically left
+    /// sparse. Set this flag to reset the clone to non-sparse if the source file was non-sparse.
     /// </summary>
-    NoSparseFileCheck = 0x02,
+    DestinationMustMatchSourceSparseness = 0x02,
 
     /// <summary>
     /// Do not serialize clone creation if the OS's CoW facility cannot handle multi-threaded clone calls

--- a/lib/Windows/NativeMethods.cs
+++ b/lib/Windows/NativeMethods.cs
@@ -31,6 +31,7 @@ internal static class NativeMethods
         };
     }
 
+    public const int FILE_FLAG_NO_BUFFERING = 0x20000000;
 
     [DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Auto)]
     [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]

--- a/tests/benchmark/CoWBenchmark.csproj
+++ b/tests/benchmark/CoWBenchmark.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Improve perf by setting the empty destination file to sparse before setting size and cloning, and by adding FILE_FLAG_NO_BUFFERING to the destination file handle. New default behavior is to leave the resulting destination file as sparse. Removed `CloneFlags.NoSparseFileCheck` and added new `CloneFlags.DestinationMustMatchSourceSparseness` if the caller desires the result to be non-sparse if the source file is.

Published new package version 0.2.0. Minor version increase based on changes to flags and default behavior.