### PR TITLE
Ignore empty SD card readers

### DIFF
--- a/lib/Windows/VolumeInfoCache.cs
+++ b/lib/Windows/VolumeInfoCache.cs
@@ -11,14 +11,14 @@ internal sealed class VolumeInfoCache
 {
     private sealed class SubPathAndVolume
     {
-        public SubPathAndVolume(string subPath, VolumeInfo volumeInfo)
+        public SubPathAndVolume(string subPath, VolumeInfo? volumeInfo)
         {
             SubPath = subPath;
             Volume = volumeInfo;
         }
 
         public readonly string SubPath;
-        public readonly VolumeInfo Volume;
+        public readonly VolumeInfo? Volume;
     }
 
     private static readonly char[] Backslash = { '\\' };
@@ -28,7 +28,7 @@ internal sealed class VolumeInfoCache
 
     public static VolumeInfoCache BuildFromCurrentFilesystem()
     {
-        var fsInfo = new List<(VolumePaths, VolumeInfo)>();
+        var fsInfo = new List<(VolumePaths, VolumeInfo?)>();
         using var volumeEnum = new VolumeEnumerator();
         foreach (VolumePaths volumePaths in volumeEnum.GetVolumesAndVolumePaths())
         {
@@ -39,7 +39,7 @@ internal sealed class VolumeInfoCache
     }
 
     // Exposed for unit testing.
-    internal VolumeInfoCache(IList<(VolumePaths, VolumeInfo)> volumesAndMountedPaths)
+    internal VolumeInfoCache(IList<(VolumePaths, VolumeInfo?)> volumesAndMountedPaths)
     {
         _driveLetterSubPathsSortedInReverseOrder = new SubPathAndVolume[26][];
         for (int i = 0; i < _driveLetterSubPathsSortedInReverseOrder.Length; i++)
@@ -47,7 +47,7 @@ internal sealed class VolumeInfoCache
             _driveLetterSubPathsSortedInReverseOrder[i] = Array.Empty<SubPathAndVolume>();
         }
 
-        foreach ((VolumePaths volumePaths, VolumeInfo volumeInfo) in volumesAndMountedPaths)
+        foreach ((VolumePaths volumePaths, VolumeInfo? volumeInfo) in volumesAndMountedPaths)
         {
             foreach (string mountedPath in volumePaths.MountedAtPaths)
             {
@@ -94,6 +94,11 @@ internal sealed class VolumeInfoCache
         {
             if (path.IsSubpathOf(spv.SubPath))
             {
+                if (spv.Volume == null)
+                {
+                    break;
+                }
+
                 return spv.Volume;
             }
         }
@@ -102,7 +107,9 @@ internal sealed class VolumeInfoCache
                                     "If the drive was added recently you may need to recreate the filesystem cache.");
     }
 
-    private static VolumeInfo GetVolumeInfo(VolumePaths volumePaths)
+    private const int ERROR_NOT_READY = 21;
+
+    private static VolumeInfo? GetVolumeInfo(VolumePaths volumePaths)
     {
         bool result = NativeMethods.GetVolumeInformation(
             volumePaths.VolumeName,
@@ -116,6 +123,11 @@ internal sealed class VolumeInfoCache
         if (!result)
         {
             int lastErr = Marshal.GetLastWin32Error();
+            if (lastErr == ERROR_NOT_READY)
+            {
+                return null;
+            }
+
             NativeMethods.ThrowSpecificIoException(lastErr,
                 $"Failed retrieving volume information for {volumePaths.PrimaryDriveRootPath} with winerror {lastErr}");
         }

--- a/lib/Windows/VolumeInfoCache.cs
+++ b/lib/Windows/VolumeInfoCache.cs
@@ -108,6 +108,7 @@ internal sealed class VolumeInfoCache
     }
 
     private const int ERROR_NOT_READY = 21;
+    private const int ERROR_INVALID_PARAMETER = 87;
 
     private static VolumeInfo? GetVolumeInfo(VolumePaths volumePaths)
     {
@@ -123,7 +124,7 @@ internal sealed class VolumeInfoCache
         if (!result)
         {
             int lastErr = Marshal.GetLastWin32Error();
-            if (lastErr == ERROR_NOT_READY)
+            if (lastErr == ERROR_NOT_READY || lastErr == ERROR_INVALID_PARAMETER)
             {
                 return null;
             }


### PR DESCRIPTION
Some SD Card readers show a drive letter even when empty.  Instead of erroring out, let's just ignore those.