### PR TITLE
Let Mac, Linux implementations return false for capability checks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,7 @@
   <PropertyGroup>
 
     <!-- DOCSYNC: When changing version number update README.md -->
-    <Version>0.3.2.0</Version>
+    <Version>0.3.3.0</Version>
 
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ File clones on Windows do not actually allocate space on-drive for the clone. Th
 
 [![NuGet version (CopyOnWrite)](https://img.shields.io/nuget/v/CopyOnWrite?style=plastic)](https://www.nuget.org/packages/CopyOnWrite)
 
+* 0.3.3 July 2023: For Linux and Mac unimplemented filesystems, return false from `CopyOnWriteLinkSupported...` methods to avoid the need for checking for Windows OS before calling.
 * 0.3.2 February 2023: Fix issue with ERROR_UNRECOGNIZED_VOLUME returned from some volumes causing an error on initialization on some machines.
 * 0.3.1 February 2023: Fix issue with Windows drive information scanning hanging reading removable SD Card drives. Updated README with Windows clone behavior.
 * 0.3.0 January 2023: Remove Windows serialization by path along with `CloneFlags.NoSerializedCloning` and the `useCrossProcessLocksWhereApplicable` flag to `CopyOnWriteFilesystemFactory`. The related concurrency bug in Windows was fixed in recent patches and retested on Windows 11.

--- a/lib/Linux/LinuxCopyOnWriteFilesystem.cs
+++ b/lib/Linux/LinuxCopyOnWriteFilesystem.cs
@@ -14,12 +14,12 @@ internal sealed class LinuxCopyOnWriteFilesystem : ICopyOnWriteFilesystem
     public bool CopyOnWriteLinkSupportedBetweenPaths(string source, string destination, bool pathsAreFullyResolved = false)
     {
         // TODO: Implement FS probing and return a real value.
-        throw new NotImplementedException();
+        return false;
     }
 
     public bool CopyOnWriteLinkSupportedInDirectoryTree(string rootDirectory, bool pathIsFullyResolved = false)
     {
-        throw new NotImplementedException();
+        return false;
     }
 
     public void CloneFile(string source, string destination) => CloneFile(source, destination, CloneFlags.None);
@@ -45,6 +45,5 @@ internal sealed class LinuxCopyOnWriteFilesystem : ICopyOnWriteFilesystem
 
     public void ClearFilesystemCache()
     {
-        throw new NotImplementedException();
     }
 }

--- a/lib/Mac/MacCopyOnWriteFilesystem.cs
+++ b/lib/Mac/MacCopyOnWriteFilesystem.cs
@@ -13,16 +13,12 @@ internal sealed class MacCopyOnWriteFilesystem : ICopyOnWriteFilesystem
 
     public bool CopyOnWriteLinkSupportedBetweenPaths(string source, string destination, bool pathsAreFullyResolved = false)
     {
-        // AppleFS always supports CoW.
-        // return true;
-        throw new NotImplementedException();
+        return false;
     }
 
     public bool CopyOnWriteLinkSupportedInDirectoryTree(string rootDirectory, bool pathIsFullyResolved = false)
     {
-        // AppleFS always supports CoW.
-        // return true;
-        throw new NotImplementedException();
+        return false;
     }
 
     public void CloneFile(string source, string destination) => CloneFile(source, destination, CloneFlags.None);
@@ -48,6 +44,5 @@ internal sealed class MacCopyOnWriteFilesystem : ICopyOnWriteFilesystem
 
     public void ClearFilesystemCache()
     {
-        throw new NotImplementedException();
     }
 }


### PR DESCRIPTION
Update Linux and Mac empty implementations to return sensible defaults instead of throwing `NotImplementedException` for `CopyOnWriteLinkSupported...` methods to avoid the need for OS-based if statements before calling.