### PR TITLE
Use a consistent AssemblyVersion

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,7 +24,8 @@
   <PropertyGroup>
 
     <!-- DOCSYNC: When changing version number update README.md -->
-    <Version>0.3.4.0</Version>
+    <Version>0.3.5.0</Version>
+    <AssemblyVersion>0.0.0.1</AssemblyVersion>
 
     <Company>Microsoft</Company>
     <Copyright>Copyright (c) Microsoft Corporation</Copyright>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ File clones on Windows do not actually allocate space on-drive for the clone. Th
 
 [![NuGet version (CopyOnWrite)](https://img.shields.io/nuget/v/CopyOnWrite?style=plastic)](https://www.nuget.org/packages/CopyOnWrite)
 
+* 0.3.5 July 2023: Set AssemblyVersion to 0.0.0.1 to allow mixing different minor-version binaries from different packages in the same appdomain/process.
 * 0.3.4 July 2023: Handle locked BitLocker volume during volume scan.
 * 0.3.3 July 2023: For Linux and Mac unimplemented filesystems, return false from `CopyOnWriteLinkSupported...` methods to avoid the need for checking for Windows OS before calling.
 * 0.3.2 February 2023: Fix issue with ERROR_UNRECOGNIZED_VOLUME returned from some volumes causing an error on initialization on some machines.


### PR DESCRIPTION
Set initially to 0.0.0.1 at the 0 major version To allow mixing different minor versions in the same process space from different packages.