### PR TITLE
New CoW-in-Win32 data, and move to newer packages and SDKs

### DIFF
--- a/BenchmarkData/BenchmarkData.md
+++ b/BenchmarkData/BenchmarkData.md
@@ -9,7 +9,7 @@ Defender real-time scanning was disabled in the test directory. See CoWCompariso
 
 ### Benchmark data in reverse temporal order
 
-* Jan 2024 - Windows [Preview Win11 23H2 with copy-on-write implementation built into OS APIs](./Win11_23H2_Jan2024_10.0.26020.1000.md) (with feature flag turned on)
+* Jan 2024 - Windows [Preview Win11 23H2 with copy-on-write implementation built into OS APIs](./Win11_23H2_Jan2024_10.0.26020.1000.md) (with feature flag turned on) - fixes large file clone performance
 * Oct 2023 - Windows [Canary Win11 22H2 with early copy-on-write implementation built into OS APIs](./Win11_22H2_Oct2023_10.0.25982.1000.md)
 * Oct 2023 - Windows [Win11 22H2 initial Dev Drive release](./Win11_22H2_Oct2023_10.0.22621.2506.md)
 * May 2023 - Windows [prerelease Dev Drive](./Win11_22H2_May2023.md)

--- a/BenchmarkData/BenchmarkData.md
+++ b/BenchmarkData/BenchmarkData.md
@@ -9,6 +9,7 @@ Defender real-time scanning was disabled in the test directory. See CoWCompariso
 
 ### Benchmark data in reverse temporal order
 
+* Jan 2024 - Windows [Preview Win11 23H2 with copy-on-write implementation built into OS APIs](./Win11_23H2_Jan2024_10.0.26020.1000.md) (with feature flag turned on)
 * Oct 2023 - Windows [Canary Win11 22H2 with early copy-on-write implementation built into OS APIs](./Win11_22H2_Oct2023_10.0.25982.1000.md)
 * Oct 2023 - Windows [Win11 22H2 initial Dev Drive release](./Win11_22H2_Oct2023_10.0.22621.2506.md)
 * May 2023 - Windows [prerelease Dev Drive](./Win11_22H2_May2023.md)

--- a/BenchmarkData/Win11_23H2_Jan2024_10.0.26020.1000.md
+++ b/BenchmarkData/Win11_23H2_Jan2024_10.0.26020.1000.md
@@ -1,0 +1,101 @@
+Benchmark numbers with Dev Drive perf fixes, Windows Insider Preview Jan 2024 with [prerelease CoW-in-Win32](https://blogs.windows.com/windows-insider/2023/10/25/announcing-windows-11-insider-preview-build-25982-canary-channel/) feature flag turned on. Win11 23H2 10.0.26020.1000, 16-core Azure AMD v5 VM.
+
+`ExtentsOnly` = Files to be copied/cloned were created only by setting the file extents.
+`WroteData` = Files were also written to. ReFS/Dev Drive behaves differently in this case.
+
+BenchmarkDotNet v0.13.12, Windows 11 (10.0.26020.1000)
+AMD Ryzen 7 PRO 4750U with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 8.0.101
+  [Host]     : .NET 6.0.26 (6.0.2623.60508), X64 RyuJIT AVX2
+  Job-JEUCCL : .NET 6.0.26 (6.0.2623.60508), X64 RyuJIT AVX2
+
+## Disable Write Cache Flush flag = Enabled
+
+| Method    | FileSize | FileContents | Mean       | Error     | StdDev      | Median     | Ratio | RatioSD |
+|---------- |--------- |------------- |-----------:|----------:|------------:|-----------:|------:|--------:|
+| File.Copy | 0        | ExtentsOnly  |   260.5 us |  10.12 us |    29.05 us |   259.6 us |  1.00 |    0.00 |
+| CoW       | 0        | ExtentsOnly  |   229.9 us |   5.58 us |    16.10 us |   228.4 us |  0.89 |    0.11 |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 0        | WroteData    |   237.1 us |   7.70 us |    22.47 us |   230.1 us |  1.00 |    0.00 |
+| CoW       | 0        | WroteData    |   229.0 us |   5.77 us |    16.37 us |   228.7 us |  0.97 |    0.11 |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 1        | ExtentsOnly  |   538.8 us |  20.13 us |    57.76 us |   526.8 us |  1.00 |    0.00 |
+| CoW       | 1        | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 1        | WroteData    |   526.4 us |  12.42 us |    35.43 us |   530.7 us |  1.00 |    0.00 |
+| CoW       | 1        | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 1024     | ExtentsOnly  |   534.0 us |  17.85 us |    52.62 us |   526.9 us |  1.00 |    0.00 |
+| CoW       | 1024     | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 1024     | WroteData    |   518.8 us |  18.06 us |    52.69 us |   523.0 us |  1.00 |    0.00 |
+| CoW       | 1024     | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 16384    | ExtentsOnly  |   499.3 us |  24.00 us |    68.07 us |   482.5 us |  1.00 |    0.00 |
+| CoW       | 16384    | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 16384    | WroteData    |   555.4 us |  20.17 us |    58.19 us |   550.2 us |  1.00 |    0.00 |
+| CoW       | 16384    | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 262144   | ExtentsOnly  |   716.1 us |  21.16 us |    61.71 us |   712.4 us |  1.00 |    0.00 |
+| CoW       | 262144   | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 262144   | WroteData    |   632.1 us |  17.40 us |    50.19 us |   626.1 us |  1.00 |    0.00 |
+| CoW       | 262144   | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 1048576  | ExtentsOnly  | 1,211.9 us |  39.56 us |   107.64 us | 1,192.3 us |  1.00 |    0.00 |
+| CoW       | 1048576  | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 1048576  | WroteData    | 1,184.9 us |  27.81 us |    79.35 us | 1,171.1 us |  1.00 |    0.00 |
+| CoW       | 1048576  | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 16777216 | ExtentsOnly  | 8,307.6 us | 475.35 us | 1,301.27 us | 7,787.6 us |  1.00 |    0.00 |
+| CoW       | 16777216 | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
+|           |          |              |            |           |             |            |       |         |
+| File.Copy | 16777216 | WroteData    | 8,553.3 us | 318.46 us |   892.99 us | 8,275.6 us |  1.00 |    0.00 |
+| CoW       | 16777216 | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
+
+## Disable Write Cache Flush flag = Disabled (OS default)
+|    Method | FileSize | FileContents |     Mean |    Error |   StdDev |   Median | Ratio | RatioSD |
+|---------- |--------- |------------- |---------:|---------:|---------:|---------:|------:|--------:|
+| File.Copy |        0 |  ExtentsOnly | 167.8 us |  1.40 us |  1.09 us | 168.0 us |  1.00 |    0.00 |
+|       CoW |        0 |  ExtentsOnly | 150.4 us |  2.49 us |  1.94 us | 151.0 us |  0.90 |    0.01 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |        0 |    WroteData | 168.7 us |  2.81 us |  3.46 us | 167.8 us |  1.00 |    0.00 |
+|       CoW |        0 |    WroteData | 149.9 us |  2.88 us |  2.41 us | 150.2 us |  0.89 |    0.03 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |        1 |  ExtentsOnly | 252.2 us |  5.11 us | 14.57 us | 244.7 us |  1.00 |    0.00 |
+|       CoW |        1 |  ExtentsOnly | 188.7 us |  4.19 us | 11.88 us | 182.9 us |  0.75 |    0.06 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |        1 |    WroteData | 469.5 us |  9.35 us | 22.03 us | 471.7 us |  1.00 |    0.00 |
+|       CoW |        1 |    WroteData | 394.2 us |  8.24 us | 23.65 us | 393.2 us |  0.84 |    0.06 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |     1024 |  ExtentsOnly | 285.2 us |  5.69 us | 14.98 us | 277.4 us |  1.00 |    0.00 |
+|       CoW |     1024 |  ExtentsOnly | 219.3 us |  4.37 us | 12.19 us | 213.1 us |  0.77 |    0.06 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |     1024 |    WroteData | 499.3 us |  9.94 us | 21.18 us | 499.7 us |  1.00 |    0.00 |
+|       CoW |     1024 |    WroteData | 439.1 us |  9.02 us | 26.18 us | 435.5 us |  0.88 |    0.06 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |    16384 |  ExtentsOnly | 275.1 us |  5.55 us | 15.91 us | 267.9 us |  1.00 |    0.00 |
+|       CoW |    16384 |  ExtentsOnly | 217.9 us |  4.35 us | 11.85 us | 213.1 us |  0.79 |    0.06 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |    16384 |    WroteData | 285.0 us |  5.52 us | 15.40 us | 280.4 us |  1.00 |    0.00 |
+|       CoW |    16384 |    WroteData | 212.6 us |  2.91 us |  5.02 us | 211.5 us |  0.74 |    0.04 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |   262144 |  ExtentsOnly | 276.8 us |  5.65 us | 16.40 us | 269.4 us |  1.00 |    0.00 |
+|       CoW |   262144 |  ExtentsOnly | 218.9 us |  4.37 us | 11.51 us | 214.0 us |  0.79 |    0.05 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |   262144 |    WroteData | 278.2 us |  5.53 us | 14.56 us | 270.9 us |  1.00 |    0.00 |
+|       CoW |   262144 |    WroteData | 215.3 us |  4.29 us |  7.95 us | 212.1 us |  0.78 |    0.04 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |  1048576 |  ExtentsOnly | 276.6 us |  5.52 us | 11.16 us | 273.4 us |  1.00 |    0.00 |
+|       CoW |  1048576 |  ExtentsOnly | 231.0 us |  6.36 us | 18.05 us | 225.5 us |  0.82 |    0.07 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy |  1048576 |    WroteData | 284.1 us |  5.72 us | 16.43 us | 276.7 us |  1.00 |    0.00 |
+|       CoW |  1048576 |    WroteData | 223.7 us |  5.10 us | 14.46 us | 219.2 us |  0.79 |    0.06 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 16777216 |  ExtentsOnly | 498.1 us |  9.54 us | 20.74 us | 496.8 us |  1.00 |    0.00 |
+|       CoW | 16777216 |  ExtentsOnly | 235.7 us |  3.52 us |  2.75 us | 236.0 us |  0.48 |    0.02 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 16777216 |    WroteData | 545.4 us | 11.69 us | 33.36 us | 547.4 us |  1.00 |    0.00 |
+|       CoW | 16777216 |    WroteData | 239.7 us |  5.50 us | 15.78 us | 232.2 us |  0.44 |    0.04 |

--- a/BenchmarkData/Win11_23H2_Jan2024_10.0.26020.1000.md
+++ b/BenchmarkData/Win11_23H2_Jan2024_10.0.26020.1000.md
@@ -1,101 +1,100 @@
-Benchmark numbers with Dev Drive perf fixes, Windows Insider Preview Jan 2024 with [prerelease CoW-in-Win32](https://blogs.windows.com/windows-insider/2023/10/25/announcing-windows-11-insider-preview-build-25982-canary-channel/) feature flag turned on. Win11 23H2 10.0.26020.1000, 16-core Azure AMD v5 VM.
+Benchmark numbers with Dev Drive perf fixes for large file cloning: The fixes bring the cost of `File.Copy` close to the CoW package results particularly for large files. Windows Insider Preview Jan 2024 with [prerelease CoW-in-Win32](https://blogs.windows.com/windows-insider/2023/10/25/announcing-windows-11-insider-preview-build-25982-canary-channel/) feature flag turned on. Win11 23H2 10.0.26020.1000, 16-core Azure AMD v5 VM.
 
 `ExtentsOnly` = Files to be copied/cloned were created only by setting the file extents.
 `WroteData` = Files were also written to. ReFS/Dev Drive behaves differently in this case.
 
-BenchmarkDotNet v0.13.12, Windows 11 (10.0.26020.1000)
-AMD Ryzen 7 PRO 4750U with Radeon Graphics, 1 CPU, 16 logical and 8 physical cores
-.NET SDK 8.0.101
+BenchmarkDotNet v0.13.12, Windows 11 (10.0.26020.1000) (Hyper-V)
+AMD EPYC 7763, 1 CPU, 16 logical and 8 physical cores
+.NET SDK 6.0.417
   [Host]     : .NET 6.0.26 (6.0.2623.60508), X64 RyuJIT AVX2
-  Job-JEUCCL : .NET 6.0.26 (6.0.2623.60508), X64 RyuJIT AVX2
+  Job-DIYMKO : .NET 6.0.26 (6.0.2623.60508), X64 RyuJIT AVX2
 
 ## Disable Write Cache Flush flag = Enabled
-
-| Method    | FileSize | FileContents | Mean       | Error     | StdDev      | Median     | Ratio | RatioSD |
-|---------- |--------- |------------- |-----------:|----------:|------------:|-----------:|------:|--------:|
-| File.Copy | 0        | ExtentsOnly  |   260.5 us |  10.12 us |    29.05 us |   259.6 us |  1.00 |    0.00 |
-| CoW       | 0        | ExtentsOnly  |   229.9 us |   5.58 us |    16.10 us |   228.4 us |  0.89 |    0.11 |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 0        | WroteData    |   237.1 us |   7.70 us |    22.47 us |   230.1 us |  1.00 |    0.00 |
-| CoW       | 0        | WroteData    |   229.0 us |   5.77 us |    16.37 us |   228.7 us |  0.97 |    0.11 |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 1        | ExtentsOnly  |   538.8 us |  20.13 us |    57.76 us |   526.8 us |  1.00 |    0.00 |
-| CoW       | 1        | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 1        | WroteData    |   526.4 us |  12.42 us |    35.43 us |   530.7 us |  1.00 |    0.00 |
-| CoW       | 1        | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 1024     | ExtentsOnly  |   534.0 us |  17.85 us |    52.62 us |   526.9 us |  1.00 |    0.00 |
-| CoW       | 1024     | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 1024     | WroteData    |   518.8 us |  18.06 us |    52.69 us |   523.0 us |  1.00 |    0.00 |
-| CoW       | 1024     | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 16384    | ExtentsOnly  |   499.3 us |  24.00 us |    68.07 us |   482.5 us |  1.00 |    0.00 |
-| CoW       | 16384    | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 16384    | WroteData    |   555.4 us |  20.17 us |    58.19 us |   550.2 us |  1.00 |    0.00 |
-| CoW       | 16384    | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 262144   | ExtentsOnly  |   716.1 us |  21.16 us |    61.71 us |   712.4 us |  1.00 |    0.00 |
-| CoW       | 262144   | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 262144   | WroteData    |   632.1 us |  17.40 us |    50.19 us |   626.1 us |  1.00 |    0.00 |
-| CoW       | 262144   | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 1048576  | ExtentsOnly  | 1,211.9 us |  39.56 us |   107.64 us | 1,192.3 us |  1.00 |    0.00 |
-| CoW       | 1048576  | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 1048576  | WroteData    | 1,184.9 us |  27.81 us |    79.35 us | 1,171.1 us |  1.00 |    0.00 |
-| CoW       | 1048576  | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 16777216 | ExtentsOnly  | 8,307.6 us | 475.35 us | 1,301.27 us | 7,787.6 us |  1.00 |    0.00 |
-| CoW       | 16777216 | ExtentsOnly  |         NA |        NA |          NA |         NA |     ? |       ? |
-|           |          |              |            |           |             |            |       |         |
-| File.Copy | 16777216 | WroteData    | 8,553.3 us | 318.46 us |   892.99 us | 8,275.6 us |  1.00 |    0.00 |
-| CoW       | 16777216 | WroteData    |         NA |        NA |          NA |         NA |     ? |       ? |
+| Method    | FileSize | FileContents | Mean     | Error    | StdDev   | Median   | Ratio | RatioSD |
+|---------- |--------- |------------- |---------:|---------:|---------:|---------:|------:|--------:|
+| File.Copy | 0        | ExtentsOnly  | 228.7 us |  7.45 us | 21.25 us | 230.1 us |  1.00 |    0.00 |
+| CoW       | 0        | ExtentsOnly  | 184.1 us |  4.07 us | 11.69 us | 184.7 us |  0.81 |    0.09 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 0        | WroteData    | 225.0 us |  6.61 us | 18.96 us | 227.6 us |  1.00 |    0.00 |
+| CoW       | 0        | WroteData    | 180.8 us |  4.20 us | 12.04 us | 178.9 us |  0.81 |    0.08 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 1        | ExtentsOnly  | 402.1 us |  8.04 us | 15.29 us | 407.7 us |  1.00 |    0.00 |
+| CoW       | 1        | ExtentsOnly  | 729.1 us | 21.00 us | 60.58 us | 728.0 us |  1.82 |    0.13 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 1        | WroteData    | 411.2 us |  8.14 us | 19.67 us | 412.2 us |  1.00 |    0.00 |
+| CoW       | 1        | WroteData    | 745.9 us | 19.52 us | 56.31 us | 741.0 us |  1.83 |    0.15 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 1024     | ExtentsOnly  | 427.0 us |  7.38 us |  6.54 us | 429.5 us |  1.00 |    0.00 |
+| CoW       | 1024     | ExtentsOnly  | 694.6 us | 13.84 us | 32.89 us | 690.9 us |  1.63 |    0.07 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 1024     | WroteData    | 399.3 us |  7.93 us | 18.23 us | 399.7 us |  1.00 |    0.00 |
+| CoW       | 1024     | WroteData    | 710.4 us | 18.48 us | 53.32 us | 700.8 us |  1.80 |    0.16 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 16384    | ExtentsOnly  | 357.9 us |  7.10 us | 18.95 us | 363.1 us |  1.00 |    0.00 |
+| CoW       | 16384    | ExtentsOnly  | 273.8 us |  5.45 us | 12.96 us | 274.5 us |  0.77 |    0.06 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 16384    | WroteData    | 346.9 us |  9.04 us | 25.64 us | 354.5 us |  1.00 |    0.00 |
+| CoW       | 16384    | WroteData    | 286.5 us | 11.16 us | 32.19 us | 274.3 us |  0.83 |    0.10 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 262144   | ExtentsOnly  | 354.8 us |  7.37 us | 21.02 us | 360.8 us |  1.00 |    0.00 |
+| CoW       | 262144   | ExtentsOnly  | 273.6 us |  5.45 us | 13.87 us | 273.6 us |  0.78 |    0.07 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 262144   | WroteData    | 359.0 us |  7.17 us | 19.14 us | 363.4 us |  1.00 |    0.00 |
+| CoW       | 262144   | WroteData    | 270.7 us |  5.40 us | 12.94 us | 269.0 us |  0.75 |    0.06 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 1048576  | ExtentsOnly  | 349.4 us |  8.64 us | 24.36 us | 356.9 us |  1.00 |    0.00 |
+| CoW       | 1048576  | ExtentsOnly  | 281.9 us |  5.65 us | 15.75 us | 279.3 us |  0.81 |    0.07 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 1048576  | WroteData    | 361.3 us |  8.60 us | 24.39 us | 365.3 us |  1.00 |    0.00 |
+| CoW       | 1048576  | WroteData    | 277.0 us |  5.54 us |  9.99 us | 277.2 us |  0.76 |    0.06 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 16777216 | ExtentsOnly  | 391.9 us |  9.73 us | 27.75 us | 398.2 us |  1.00 |    0.00 |
+| CoW       | 16777216 | ExtentsOnly  | 310.6 us |  5.82 us |  5.72 us | 308.9 us |  0.80 |    0.06 |
+|           |          |              |          |          |          |          |       |         |
+| File.Copy | 16777216 | WroteData    | 424.9 us | 14.11 us | 40.47 us | 422.6 us |  1.00 |    0.00 |
+| CoW       | 16777216 | WroteData    | 393.6 us |  8.86 us | 24.85 us | 390.4 us |  0.94 |    0.10 |
 
 ## Disable Write Cache Flush flag = Disabled (OS default)
-|    Method | FileSize | FileContents |     Mean |    Error |   StdDev |   Median | Ratio | RatioSD |
+| Method    | FileSize | FileContents | Mean     | Error    | StdDev   | Median   | Ratio | RatioSD |
 |---------- |--------- |------------- |---------:|---------:|---------:|---------:|------:|--------:|
-| File.Copy |        0 |  ExtentsOnly | 167.8 us |  1.40 us |  1.09 us | 168.0 us |  1.00 |    0.00 |
-|       CoW |        0 |  ExtentsOnly | 150.4 us |  2.49 us |  1.94 us | 151.0 us |  0.90 |    0.01 |
+| File.Copy | 0        | ExtentsOnly  | 227.7 us |  7.41 us | 21.27 us | 232.2 us |  1.00 |    0.00 |
+| CoW       | 0        | ExtentsOnly  | 192.8 us |  3.92 us | 11.00 us | 190.3 us |  0.85 |    0.09 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |        0 |    WroteData | 168.7 us |  2.81 us |  3.46 us | 167.8 us |  1.00 |    0.00 |
-|       CoW |        0 |    WroteData | 149.9 us |  2.88 us |  2.41 us | 150.2 us |  0.89 |    0.03 |
+| File.Copy | 0        | WroteData    | 233.2 us |  5.76 us | 16.25 us | 236.8 us |  1.00 |    0.00 |
+| CoW       | 0        | WroteData    | 202.7 us |  4.02 us |  9.23 us | 201.8 us |  0.87 |    0.08 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |        1 |  ExtentsOnly | 252.2 us |  5.11 us | 14.57 us | 244.7 us |  1.00 |    0.00 |
-|       CoW |        1 |  ExtentsOnly | 188.7 us |  4.19 us | 11.88 us | 182.9 us |  0.75 |    0.06 |
+| File.Copy | 1        | ExtentsOnly  | 420.7 us |  7.96 us |  9.48 us | 424.3 us |  1.00 |    0.00 |
+| CoW       | 1        | ExtentsOnly  | 695.7 us | 17.11 us | 47.69 us | 694.7 us |  1.70 |    0.12 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |        1 |    WroteData | 469.5 us |  9.35 us | 22.03 us | 471.7 us |  1.00 |    0.00 |
-|       CoW |        1 |    WroteData | 394.2 us |  8.24 us | 23.65 us | 393.2 us |  0.84 |    0.06 |
+| File.Copy | 1        | WroteData    | 419.9 us |  8.35 us | 17.05 us | 419.2 us |  1.00 |    0.00 |
+| CoW       | 1        | WroteData    | 671.5 us | 19.24 us | 54.91 us | 674.1 us |  1.62 |    0.16 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |     1024 |  ExtentsOnly | 285.2 us |  5.69 us | 14.98 us | 277.4 us |  1.00 |    0.00 |
-|       CoW |     1024 |  ExtentsOnly | 219.3 us |  4.37 us | 12.19 us | 213.1 us |  0.77 |    0.06 |
+| File.Copy | 1024     | ExtentsOnly  | 438.0 us |  8.74 us | 15.76 us | 435.4 us |  1.00 |    0.00 |
+| CoW       | 1024     | ExtentsOnly  | 716.9 us | 15.63 us | 44.09 us | 710.8 us |  1.67 |    0.12 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |     1024 |    WroteData | 499.3 us |  9.94 us | 21.18 us | 499.7 us |  1.00 |    0.00 |
-|       CoW |     1024 |    WroteData | 439.1 us |  9.02 us | 26.18 us | 435.5 us |  0.88 |    0.06 |
+| File.Copy | 1024     | WroteData    | 419.8 us |  8.23 us | 10.40 us | 422.8 us |  1.00 |    0.00 |
+| CoW       | 1024     | WroteData    | 719.3 us | 17.08 us | 49.00 us | 708.9 us |  1.77 |    0.13 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |    16384 |  ExtentsOnly | 275.1 us |  5.55 us | 15.91 us | 267.9 us |  1.00 |    0.00 |
-|       CoW |    16384 |  ExtentsOnly | 217.9 us |  4.35 us | 11.85 us | 213.1 us |  0.79 |    0.06 |
+| File.Copy | 16384    | ExtentsOnly  | 367.1 us |  7.28 us | 17.57 us | 369.3 us |  1.00 |    0.00 |
+| CoW       | 16384    | ExtentsOnly  | 293.2 us |  5.80 us | 12.10 us | 294.8 us |  0.80 |    0.05 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |    16384 |    WroteData | 285.0 us |  5.52 us | 15.40 us | 280.4 us |  1.00 |    0.00 |
-|       CoW |    16384 |    WroteData | 212.6 us |  2.91 us |  5.02 us | 211.5 us |  0.74 |    0.04 |
+| File.Copy | 16384    | WroteData    | 361.2 us |  7.16 us | 13.09 us | 363.2 us |  1.00 |    0.00 |
+| CoW       | 16384    | WroteData    | 298.5 us |  9.07 us | 25.88 us | 290.3 us |  0.88 |    0.07 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |   262144 |  ExtentsOnly | 276.8 us |  5.65 us | 16.40 us | 269.4 us |  1.00 |    0.00 |
-|       CoW |   262144 |  ExtentsOnly | 218.9 us |  4.37 us | 11.51 us | 214.0 us |  0.79 |    0.05 |
+| File.Copy | 262144   | ExtentsOnly  | 370.1 us |  7.37 us | 17.66 us | 375.5 us |  1.00 |    0.00 |
+| CoW       | 262144   | ExtentsOnly  | 327.0 us | 15.29 us | 44.59 us | 318.5 us |  0.92 |    0.12 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |   262144 |    WroteData | 278.2 us |  5.53 us | 14.56 us | 270.9 us |  1.00 |    0.00 |
-|       CoW |   262144 |    WroteData | 215.3 us |  4.29 us |  7.95 us | 212.1 us |  0.78 |    0.04 |
+| File.Copy | 262144   | WroteData    | 370.2 us |  8.79 us | 24.93 us | 373.2 us |  1.00 |    0.00 |
+| CoW       | 262144   | WroteData    | 356.6 us |  6.99 us | 13.29 us | 354.0 us |  0.95 |    0.06 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |  1048576 |  ExtentsOnly | 276.6 us |  5.52 us | 11.16 us | 273.4 us |  1.00 |    0.00 |
-|       CoW |  1048576 |  ExtentsOnly | 231.0 us |  6.36 us | 18.05 us | 225.5 us |  0.82 |    0.07 |
+| File.Copy | 1048576  | ExtentsOnly  | 367.1 us |  8.22 us | 23.17 us | 367.3 us |  1.00 |    0.00 |
+| CoW       | 1048576  | ExtentsOnly  | 359.9 us |  7.06 us |  9.66 us | 357.5 us |  1.00 |    0.06 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy |  1048576 |    WroteData | 284.1 us |  5.72 us | 16.43 us | 276.7 us |  1.00 |    0.00 |
-|       CoW |  1048576 |    WroteData | 223.7 us |  5.10 us | 14.46 us | 219.2 us |  0.79 |    0.06 |
+| File.Copy | 1048576  | WroteData    | 377.2 us |  7.52 us | 16.36 us | 377.6 us |  1.00 |    0.00 |
+| CoW       | 1048576  | WroteData    | 296.8 us |  5.87 us |  9.48 us | 298.2 us |  0.78 |    0.04 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy | 16777216 |  ExtentsOnly | 498.1 us |  9.54 us | 20.74 us | 496.8 us |  1.00 |    0.00 |
-|       CoW | 16777216 |  ExtentsOnly | 235.7 us |  3.52 us |  2.75 us | 236.0 us |  0.48 |    0.02 |
+| File.Copy | 16777216 | ExtentsOnly  | 473.2 us |  9.41 us | 21.23 us | 477.4 us |  1.00 |    0.00 |
+| CoW       | 16777216 | ExtentsOnly  | 325.8 us | 11.50 us | 33.18 us | 309.4 us |  0.71 |    0.08 |
 |           |          |              |          |          |          |          |       |         |
-| File.Copy | 16777216 |    WroteData | 545.4 us | 11.69 us | 33.36 us | 547.4 us |  1.00 |    0.00 |
-|       CoW | 16777216 |    WroteData | 239.7 us |  5.50 us | 15.78 us | 232.2 us |  0.44 |    0.04 |
+| File.Copy | 16777216 | WroteData    | 410.4 us | 12.86 us | 37.09 us | 407.4 us |  1.00 |    0.00 |
+| CoW       | 16777216 | WroteData    | 475.7 us |  8.33 us |  6.96 us | 475.9 us |  1.22 |    0.11 |

--- a/exe/CoWCloneFile.csproj
+++ b/exe/CoWCloneFile.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.CopyOnWrite</RootNamespace>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <DistribDir>$(DistribRoot)CloneFileTool\</DistribDir>
     <SelfContained>true</SelfContained>

--- a/exe/CoWCloneFile.csproj
+++ b/exe/CoWCloneFile.csproj
@@ -4,21 +4,17 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
-    <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <DistribDir>$(DistribRoot)CloneFileTool\</DistribDir>
+    <SelfContained>true</SelfContained>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\Lib\CopyOnWrite.csproj" />
   </ItemGroup>
-
-  <Target Name="PostBuildPublish" AfterTargets="PostBuildEvent" Inputs="$(OutputPath)CoWCloneFile.exe" Outputs="$(DistribDir)CoWCloneFile.exe">
-    <!-- ReadyToRun / self-contained pre-compiled .exe -->
-    <Exec Command="dotnet publish --no-build --configuration $(Configuration) --self-contained true --output $(DistribDir)" />
-  </Target>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0",
+    "version": "8.0.101",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0",
+    "version": "8.0",
     "rollForward": "latestMinor"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.400",
-    "rollForward": "feature"
+    "version": "6.0",
+    "rollForward": "latestMinor"
   }
 }

--- a/tests/benchmark/CoWBenchmark.csproj
+++ b/tests/benchmark/CoWBenchmark.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.13.2" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/benchmark/CoWBenchmark.csproj
+++ b/tests/benchmark/CoWBenchmark.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.CopyOnWrite.Benchmarking</RootNamespace>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/unit/CopyOnWriteTests.props
+++ b/tests/unit/CopyOnWriteTests.props
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Microsoft.CopyOnWrite.Tests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/unit/CopyOnWriteTests.props
+++ b/tests/unit/CopyOnWriteTests.props
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/utils/TestUtilities.csproj
+++ b/tests/utils/TestUtilities.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <RootNamespace>Microsoft.CopyOnWrite.TestUtilities</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
* Add new perf data after fix for large file clone perf was added to the Windows Insider Preview. (CoW-in-Win32 moved behind a feature flag late last year so requires turning the feature on.)
* Update most projects for .NET 8 SDK. Keep the library as net6.0 and netstandard2.0.
* Update to latest package versions.