### PR TITLE
Fix crash for Device not found

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   <PropertyGroup>
 
     <!-- DOCSYNC: When changing version number update README.md -->
-    <Version>0.3.11.0</Version>
+    <Version>0.3.12.0</Version>
     <AssemblyVersion>0.9.9999.0</AssemblyVersion>
 
     <Company>Microsoft</Company>

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ File clones on Windows do not actually allocate space on-drive for the clone. Th
 
 [![NuGet version (CopyOnWrite)](https://img.shields.io/nuget/v/CopyOnWrite?style=plastic)](https://www.nuget.org/packages/CopyOnWrite)
 
+* 0.3.12 October 2024: Add ERROR_DEV_NOT_EXIST handling on getting free disk space
 * 0.3.11 September 2024: Add ERROR_DEV_NOT_EXIST handling on volume enumeration
 * 0.3.10 September 2024: Add ERROR_NO_SUCH_DEVICE handling on volume enumeration
 * 0.3.9 September 2024: Fix https://github.com/microsoft/CopyOnWrite/issues/44 - follow up on ignoring FILE_NOT_FOUND on volume enumeration

--- a/lib/Windows/VolumeInfoCache.cs
+++ b/lib/Windows/VolumeInfoCache.cs
@@ -151,6 +151,11 @@ internal sealed class VolumeInfoCache
             out ulong _);
         if (!result)
         {
+            if (lastErr == NativeMethods.ERROR_DEV_NOT_EXIST)
+            {
+                return null;
+            }
+            
             int lastErr = Marshal.GetLastWin32Error();
             NativeMethods.ThrowSpecificIoException(lastErr,
                 $"Failed retrieving drive volume cluster layout information for {volumePaths.PrimaryDriveRootPath} with winerror {lastErr}");

--- a/lib/Windows/VolumeInfoCache.cs
+++ b/lib/Windows/VolumeInfoCache.cs
@@ -151,12 +151,12 @@ internal sealed class VolumeInfoCache
             out ulong _);
         if (!result)
         {
+            int lastErr = Marshal.GetLastWin32Error();
             if (lastErr == NativeMethods.ERROR_DEV_NOT_EXIST)
             {
                 return null;
             }
             
-            int lastErr = Marshal.GetLastWin32Error();
             NativeMethods.ThrowSpecificIoException(lastErr,
                 $"Failed retrieving drive volume cluster layout information for {volumePaths.PrimaryDriveRootPath} with winerror {lastErr}");
         }


### PR DESCRIPTION
```
The "Robocopy" task could not be instantiated from "C:\.nuget\packages\microsoft.build.artifacts\6.1.30\build\netstandard2.0\Microsoft.Build.Artifacts.dll".  System.TypeInitializationException: The type initializer for 'Microsoft.Build.Artifacts.FileSystem' threw an exception. ---> System.ComponentModel.Win32Exception: Failed retrieving volume information for A:\ with winerror 55
   at Microsoft.CopyOnWrite.Windows.NativeMethods.ThrowSpecificIoException(Int32 lastErr, String message) in D:\CoW\lib\Windows\NativeMethods.cs:line 30
   at Microsoft.CopyOnWrite.Windows.VolumeInfoCache.GetVolumeInfo(VolumePaths volumePaths) in D:\CoW\lib\Windows\VolumeInfoCache.cs:line 161
   at Microsoft.CopyOnWrite.Windows.VolumeInfoCache.BuildFromCurrentFilesystem() in D:\CoW\lib\Windows\VolumeInfoCache.cs:line 36
   at Microsoft.CopyOnWrite.CopyOnWriteFilesystemFactory.Create() in D:\CoW\lib\CopyOnWriteFilesystemFactory.cs:line 48
   at System.Lazy`1.CreateValue()
   at System.Lazy`1.LazyInitValue()
   at Microsoft.Build.Artifacts.FileSystem..cctor()
   --- End of inner exception stack trace ---
   at Microsoft.Build.Artifacts.Tasks.Robocopy..ctor()
```