### PR TITLE
Add STATUS_VHD_INVALID_STATE handling on getting volume information

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   <PropertyGroup>
 
     <!-- DOCSYNC: When changing version number update README.md -->
-    <Version>0.4.1</Version>
+    <Version>0.4.2</Version>
     <AssemblyVersion>0.9.9999.0</AssemblyVersion>
 
     <Company>Microsoft</Company>

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ File clones on Windows do not actually allocate space on-drive for the clone. Th
 
 [![NuGet version (CopyOnWrite)](https://img.shields.io/nuget/v/CopyOnWrite?style=plastic)](https://www.nuget.org/packages/CopyOnWrite)
 
-* 0.4.2 November 2024: Add STATUS_VHD_INVALID_STATE handling on getting volume information
+* 0.4.2 November 2024: Add STATUS_VHD_INVALID_STATE and ERROR_NO_SUCH_DEVICE handling on getting volume information
 * 0.4.1 October 2024: Add ERROR_DEV_NOT_EXIST handling on volume enumeration
 * 0.4.0 October 2024: Remove async versions of `CloneFile` as the implementation did not use overlapped I/O anyway. CoW support is releasing in the Server 2025 and Win11 24H2 wave, built into the `CopyFile` API suite and on by default for Dev Drive and ReFS, so overlapped I/O in this library will never be implemented. Resolves https://github.com/microsoft/CopyOnWrite/issues/50
 * 0.3.12 October 2024: Add ERROR_DEV_NOT_EXIST handling on getting free disk space

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ File clones on Windows do not actually allocate space on-drive for the clone. Th
 
 [![NuGet version (CopyOnWrite)](https://img.shields.io/nuget/v/CopyOnWrite?style=plastic)](https://www.nuget.org/packages/CopyOnWrite)
 
+* 0.4.2 November 2024: Add STATUS_VHD_INVALID_STATE handling on getting volume information
 * 0.4.1 October 2024: Add ERROR_DEV_NOT_EXIST handling on volume enumeration
 * 0.4.0 October 2024: Remove async versions of `CloneFile` as the implementation did not use overlapped I/O anyway. CoW support is releasing in the Server 2025 and Win11 24H2 wave, built into the `CopyFile` API suite and on by default for Dev Drive and ReFS, so overlapped I/O in this library will never be implemented. Resolves https://github.com/microsoft/CopyOnWrite/issues/50
 * 0.3.12 October 2024: Add ERROR_DEV_NOT_EXIST handling on getting free disk space

--- a/lib/Windows/NativeMethods.cs
+++ b/lib/Windows/NativeMethods.cs
@@ -160,6 +160,7 @@ internal static class NativeMethods
     public const int ERROR_DEV_NOT_EXIST = 55;
     public const int ERROR_MORE_DATA = 234;
     public const int ERROR_NO_SUCH_DEVICE = 433;
+    public const int STATUS_VHD_INVALID_STATE = unchecked((int)0xC03A001C);
 
     // ReFS specific WinError codes.
     public const int ERROR_BLOCK_TOO_MANY_REFERENCES = 347;

--- a/lib/Windows/VolumeInfoCache.cs
+++ b/lib/Windows/VolumeInfoCache.cs
@@ -135,7 +135,8 @@ internal sealed class VolumeInfoCache
                 lastErr == FVE_E_LOCKED_VOLUME ||
                 lastErr == NativeMethods.ERROR_ACCESS_DENIED ||
                 lastErr == NativeMethods.ERROR_FILE_NOT_FOUND ||
-                lastErr == NativeMethods.ERROR_DEV_NOT_EXIST)
+                lastErr == NativeMethods.ERROR_DEV_NOT_EXIST ||
+                lastErr == NativeMethods.STATUS_VHD_INVALID_STATE)
             {
                 return null;
             }

--- a/lib/Windows/VolumeInfoCache.cs
+++ b/lib/Windows/VolumeInfoCache.cs
@@ -136,6 +136,7 @@ internal sealed class VolumeInfoCache
                 lastErr == NativeMethods.ERROR_ACCESS_DENIED ||
                 lastErr == NativeMethods.ERROR_FILE_NOT_FOUND ||
                 lastErr == NativeMethods.ERROR_DEV_NOT_EXIST ||
+                lastErr == NativeMethods.ERROR_NO_SUCH_DEVICE ||
                 lastErr == NativeMethods.STATUS_VHD_INVALID_STATE)
             {
                 return null;


### PR DESCRIPTION
Fix for stack trace of:

```
System.TypeInitializationException: The type initializer for 'Microsoft.Build.Artifacts.FileSystem' threw an exception. ---> System.ComponentModel.Win32Exception: rFailed retrieving volume information fo \\?\Volume{guid}\\ with winerror -1069940708
   at Microsoft.CopyOnWrite.Windows.NativeMethods.ThrowSpecificIoException(Int32 lastErr, String message) in D:\CoW\lib\Windows\NativeMethods.cs:line 30
   at Microsoft.CopyOnWrite.Windows.VolumeInfoCache.GetVolumeInfo(VolumePaths volumePaths) in D:\CoW\lib\Windows\VolumeInfoCache.cs:line 161
```

and

```
System.TypeInitializationException: The type initializer for 'Microsoft.Build.Artifacts.FileSystem' threw an exception. ---> System.ComponentModel.Win32Exception: Failed retrieving volume information for \\?\Volume{guid}\\ with winerror 433
```